### PR TITLE
fix: force full screen repaint after session disconnect

### DIFF
--- a/telix/client_tui.py
+++ b/telix/client_tui.py
@@ -756,6 +756,10 @@ class SessionListScreen(Screen[None]):
                 sys.stdout.flush()
         self._refresh_table()
         self._select_row(key)
+        # Textual's app.suspend() re-enters the alternate screen buffer
+        # (which is blank) but does not mark the screen dirty for a full
+        # repaint.  Without this, widgets only redraw on hover.
+        self.screen.refresh()
 
     def _on_edit_result(self, config: SessionConfig | None) -> None:
         if config is None:


### PR DESCRIPTION
## Summary

- Fixes #1 -- session list buttons invisible after disconnect until hovered
- Adds `self.screen.refresh()` after the `app.suspend()` block in `action_connect()` to force a full screen repaint

## Root Cause

Textual's `app.suspend()` re-enters the alternate screen buffer (blank) on exit but does not mark the screen dirty for a full repaint. The compositor's `render_update()` only renders dirty regions, so unchanged widgets are never repainted. Mouse hover events then force individual widget redraws, causing buttons to "pop in" one at a time.

## Change

One line addition in `SessionListScreen.action_connect()`:

```python
self.screen.refresh()
```

This marks the entire screen as dirty so the compositor repaints all widgets immediately after resume.

## Testing

- 812 tests pass (py313)
- Manually verified: buttons render immediately after disconnect