### PR TITLE
style: apply black/isort formatting to existing modules

### DIFF
--- a/telix/autoreply.py
+++ b/telix/autoreply.py
@@ -23,6 +23,7 @@ from dataclasses import field, dataclass
 # 3rd party
 from wcwidth import strip_sequences
 
+# local
 from .client_repl_render import scramble_password
 
 if TYPE_CHECKING:
@@ -946,7 +947,10 @@ class AutoreplyEngine:
         :param reply_text: Fully substituted reply string.
         """
         from .client_repl_commands import (
-            StepResult, DispatchHooks, dispatch_one, expand_commands_ex,
+            StepResult,
+            DispatchHooks,
+            dispatch_one,
+            expand_commands_ex,
         )
 
         expanded = expand_commands_ex(reply_text)
@@ -970,8 +974,7 @@ class AutoreplyEngine:
         sent_count = 0
         for idx, cmd in enumerate(expanded.commands):
             result = await dispatch_one(
-                cmd, idx, sent_count, expanded.immediate_set, hooks,
-                mask_send=mask_send,
+                cmd, idx, sent_count, expanded.immediate_set, hooks, mask_send=mask_send
             )
             if result is StepResult.ABORT:
                 return

--- a/telix/client_repl.py
+++ b/telix/client_repl.py
@@ -15,7 +15,6 @@ from telnetlib3.stream_reader import TelnetReader, TelnetReaderUnicode
 from telnetlib3.stream_writer import TelnetWriter, TelnetWriterUnicode
 
 # local
-from .client_repl_commands import _DELAY_RE
 from .session_context import SessionContext, _CommandQueue
 
 # Re-export from sub-modules so existing ``from .client_repl import X``
@@ -85,8 +84,8 @@ from .client_repl_render import (  # noqa: F401
     _layout_toolbar,
     _until_progress,
     _center_truncate,
-    scramble_password,
     editor_cursor_col,
+    scramble_password,
 )
 from .client_repl_travel import (  # noqa: F401
     _DEFAULT_WALK_LIMIT,
@@ -111,6 +110,7 @@ from .client_repl_dialogs import (  # noqa: F401
     _launch_unified_editor,
 )
 from .client_repl_commands import (  # noqa: F401
+    _DELAY_RE,
     _REPEAT_RE,
     _TRAVEL_RE,
     _BACKTICK_RE,
@@ -964,9 +964,7 @@ if sys.platform != "win32":
                 return
             self.ar_rules_ref = cur_rules
             prev_enabled = (
-                self.autoreply_engine.enabled
-                if self.autoreply_engine is not None
-                else True
+                self.autoreply_engine.enabled if self.autoreply_engine is not None else True
             )
             if self.autoreply_engine is not None:
                 self.autoreply_engine.cancel()
@@ -1179,16 +1177,13 @@ if sys.platform != "win32":
             self.dispatch.register("KEY_F4", self._discover_mode)
             self.dispatch.register("KEY_F5", self._resume_last_walk)
             self.dispatch.register(
-                "KEY_F7",
-                lambda: _launch_unified_editor("rooms", self.ctx, self.replay_buf),
+                "KEY_F7", lambda: _launch_unified_editor("rooms", self.ctx, self.replay_buf)
             )
             self.dispatch.register(
-                "KEY_F10",
-                lambda: _launch_unified_editor("captures", self.ctx, self.replay_buf),
+                "KEY_F10", lambda: _launch_unified_editor("captures", self.ctx, self.replay_buf)
             )
             self.dispatch.register(
-                "KEY_F11",
-                lambda: _launch_unified_editor("bars", self.ctx, self.replay_buf),
+                "KEY_F11", lambda: _launch_unified_editor("bars", self.ctx, self.replay_buf)
             )
             self.toolbar.schedule_eta_refresh(
                 self.loop, self.autoreply_engine, self.editor, self.blessed_term
@@ -1386,20 +1381,16 @@ if sys.platform != "win32":
             )  # Ctrl+L
 
             self.dispatch.register(
-                "KEY_F1",
-                lambda: _launch_unified_editor("help", self.ctx, self.replay_buf),
+                "KEY_F1", lambda: _launch_unified_editor("help", self.ctx, self.replay_buf)
             )
             self.dispatch.register(
-                "KEY_F6",
-                lambda: _launch_unified_editor("highlights", self.ctx, self.replay_buf),
+                "KEY_F6", lambda: _launch_unified_editor("highlights", self.ctx, self.replay_buf)
             )
             self.dispatch.register(
-                "KEY_F8",
-                lambda: _launch_unified_editor("macros", self.ctx, self.replay_buf),
+                "KEY_F8", lambda: _launch_unified_editor("macros", self.ctx, self.replay_buf)
             )
             self.dispatch.register(
-                "KEY_F9",
-                lambda: _launch_unified_editor("autoreplies", self.ctx, self.replay_buf),
+                "KEY_F9", lambda: _launch_unified_editor("autoreplies", self.ctx, self.replay_buf)
             )
             self.dispatch.register("KEY_F21", self._toggle_autoreplies)  # Shift+F9
             self.dispatch.register("KEY_F18", self._toggle_highlights)  # Shift+F6

--- a/telix/client_repl_commands.py
+++ b/telix/client_repl_commands.py
@@ -6,21 +6,14 @@ import enum
 import asyncio
 import logging
 from time import monotonic as _monotonic
-from typing import TYPE_CHECKING, Any, Optional, Callable, Awaitable, NamedTuple
+from typing import TYPE_CHECKING, Any, Callable, Optional, Awaitable, NamedTuple
 from dataclasses import dataclass
 
 if TYPE_CHECKING:
     from .session_context import SessionContext, _CommandQueue
 
 # local
-from .client_repl_render import (
-    _ELLIPSIS,
-    _get_term,
-    _wcswidth,
-    _write_hint,
-    _flash_bg_rgb,
-)
-
+from .client_repl_render import _ELLIPSIS, _get_term, _wcswidth, _write_hint, _flash_bg_rgb
 
 _REPEAT_RE = re.compile(r"^(\d+)([A-Za-z].*)$")
 _BACKTICK_RE = re.compile(r"`[^`]*`")
@@ -46,7 +39,8 @@ class StepResult(enum.Enum):
 
 @dataclass
 class DispatchHooks:
-    """Caller-specific callbacks for :func:`dispatch_one`.
+    """
+    Caller-specific callbacks for :func:`dispatch_one`.
 
     :param ctx: Session context.
     :param log: Logger instance.
@@ -193,7 +187,8 @@ def expand_commands(line: str) -> list[str]:
 
 
 def _get_search_buffer(ctx: "SessionContext") -> Optional[Any]:
-    """Return the :class:`SearchBuffer` for *ctx*, or ``None``.
+    """
+    Return the :class:`SearchBuffer` for *ctx*, or ``None``.
 
     Works for both macro execution (where ``ctx.autoreply_engine`` is the
     engine) and autoreply execution (where the engine *is* ``self`` and
@@ -216,7 +211,8 @@ async def dispatch_one(
     hooks: DispatchHooks,
     mask_send: bool = False,
 ) -> StepResult:
-    """Dispatch a single backtick command or plain send.
+    """
+    Dispatch a single backtick command or plain send.
 
     Handles ``delay``, ``when``, ``until``, ``untils``, and plain send
     commands.  Caller keeps its own loop structure.
@@ -326,9 +322,7 @@ async def dispatch_one(
 
 
 _TRAVEL_RE = re.compile(
-    r"^`(travel|return"
-    r"|autodiscover|randomwalk|resume|home)\s*(.*?)`$",
-    re.IGNORECASE,
+    r"^`(travel|return" r"|autodiscover|randomwalk|resume|home)\s*(.*?)`$", re.IGNORECASE
 )
 
 _COMMAND_DELAY = 0.25
@@ -336,7 +330,8 @@ _MOVE_MAX_RETRIES = 2
 
 
 def _is_known_exit(cmd: str, ctx: "SessionContext") -> bool:
-    """Return ``True`` if *cmd* matches a known exit from the current room.
+    """
+    Return ``True`` if *cmd* matches a known exit from the current room.
 
     Falls back to ``True`` when room data is unavailable so that
     movement pacing is used conservatively.
@@ -670,19 +665,18 @@ async def _send_chained(
 
             if attempt < _MOVE_MAX_RETRIES:
                 log.info(
-                    "room unchanged after %r, retrying (%d/%d)",
-                    cmd, attempt + 1, _MOVE_MAX_RETRIES,
+                    "room unchanged after %r, retrying (%d/%d)", cmd, attempt + 1, _MOVE_MAX_RETRIES
                 )
             else:
                 log.warning(
-                    "room unchanged after %r, giving up after %d retries",
-                    cmd, _MOVE_MAX_RETRIES,
+                    "room unchanged after %r, giving up after %d retries", cmd, _MOVE_MAX_RETRIES
                 )
                 return
 
 
 def _macro_send(ctx: "SessionContext", log: logging.Logger, cmd: str) -> None:
-    """Send a single command for macro execution.
+    """
+    Send a single command for macro execution.
 
     :param ctx: Session context.
     :param log: Logger.

--- a/telix/client_repl_dialogs.py
+++ b/telix/client_repl_dialogs.py
@@ -210,12 +210,8 @@ def _randomwalk_dialog(replay_buf: Optional[Any] = None, session_key: str = "") 
             save_data["randomwalk_auto_evaluate"] = bool(
                 data.get("auto_evaluate", default_auto_evaluate)
             )
-            save_data["randomwalk_auto_survey"] = bool(
-                data.get("auto_survey", default_auto_survey)
-            )
-            save_data["randomwalk_autoreplies"] = bool(
-                data.get("autoreplies", default_autoreplies)
-            )
+            save_data["randomwalk_auto_survey"] = bool(data.get("auto_survey", default_auto_survey))
+            save_data["randomwalk_autoreplies"] = bool(data.get("autoreplies", default_autoreplies))
             save_prefs(session_key, save_data)
         return str(data.get("command", f"`randomwalk 999 {default_visit_level}`"))
     except (OSError, ValueError):
@@ -435,7 +431,8 @@ def _show_help(
 
 
 def _pause_on_subprocess_error(result: Optional[Any]) -> None:
-    """Pause so the user can read any error output before screen repaint.
+    """
+    Pause so the user can read any error output before screen repaint.
 
     When the TUI subprocess exits with a non-zero return code its traceback
     is already on screen (written by the child's ``_run_editor_app``).
@@ -473,14 +470,12 @@ def _launch_unified_editor(
     import tempfile
     import subprocess
 
+    from .rooms import rooms_path as _rooms_path_fn
+    from .rooms import fasttravel_path as _fasttravel_path_fn
+    from .rooms import read_fasttravel
+    from .rooms import current_room_path as _current_room_path_fn
     from ._paths import CONFIG_DIR as _config_dir
     from .client_repl import _get_term, _blocking_fds, _terminal_cleanup, _restore_after_subprocess
-    from .rooms import (
-        rooms_path as _rooms_path_fn,
-        read_fasttravel,
-        fasttravel_path as _fasttravel_path_fn,
-        current_room_path as _current_room_path_fn,
-    )
 
     session_key = ctx.session_key
     logfile = _get_logfile_path()
@@ -545,8 +540,7 @@ def _launch_unified_editor(
     cmd = [
         sys.executable,
         "-c",
-        "import sys; from telix.client_tui import unified_editor_main; "
-        "unified_editor_main()",
+        "import sys; from telix.client_tui import unified_editor_main; " "unified_editor_main()",
         params_json,
     ]
 
@@ -554,8 +548,7 @@ def _launch_unified_editor(
 
     global _editor_active  # noqa: PLW0603
     log.debug(
-        "unified_editor: pre-subprocess initial_tab=%s "
-        "TERM=%s COLORTERM=%s terminal_size=%s",
+        "unified_editor: pre-subprocess initial_tab=%s " "TERM=%s COLORTERM=%s terminal_size=%s",
         initial_tab,
         os.environ.get("TERM", ""),
         os.environ.get("COLORTERM", ""),

--- a/telix/client_repl_render.py
+++ b/telix/client_repl_render.py
@@ -561,7 +561,11 @@ def _sgr_bg(hexcolor: str) -> str:
 
 
 def _vital_bar(
-    current: Any, maximum: Any, width: int, kind: str, flash_elapsed: float = -1.0,
+    current: Any,
+    maximum: Any,
+    width: int,
+    kind: str,
+    flash_elapsed: float = -1.0,
     color_override: Optional[str] = None,
     text_fill_color: Optional[str] = None,
     text_empty_color: Optional[str] = None,
@@ -808,9 +812,14 @@ def _fill_toolbar(
             t_empty = params[6] if len(params) > 6 else None
             inner = slot.width - 2 + bonus
             frags = _vital_bar(
-                raw, maxval, inner, kind,
-                flash_elapsed=flash_elapsed, color_override=c_override,
-                text_fill_color=t_fill, text_empty_color=t_empty,
+                raw,
+                maxval,
+                inner,
+                kind,
+                flash_elapsed=flash_elapsed,
+                color_override=c_override,
+                text_fill_color=t_fill,
+                text_empty_color=t_empty,
             )
             new_w = sum(_wcswidth(t) for _, t in frags)
             return slot._replace(width=new_w, fragments=frags)
@@ -979,7 +988,8 @@ class ToolbarRenderer:
         self.out.write(CURSOR_SHOW.encode())
 
     def schedule_cursor_show(self, loop: asyncio.AbstractEventLoop) -> None:
-        """Schedule the terminal cursor to be shown after a short delay.
+        """
+        Schedule the terminal cursor to be shown after a short delay.
 
         If ``hide_cursor`` is called before the timer fires, the show is
         suppressed.  A later ``schedule_cursor_show`` will try again.
@@ -1016,9 +1026,7 @@ class ToolbarRenderer:
         slots, needs_reflash = self._build_slots(
             engine, ar_active, discover_active, randomwalk_active, now
         )
-        return self._paint(
-            slots, self._is_autoreply_bg(engine), needs_reflash
-        )
+        return self._paint(slots, self._is_autoreply_bg(engine), needs_reflash)
 
     def _ensure_gmcp_ready(self) -> bool:
         """Initialize toolbar on first GMCP data; return ``False`` if no data yet."""
@@ -1162,9 +1170,18 @@ class ToolbarRenderer:
             text_fill = resolve_text_color_hex(cfg.text_color_fill)
             text_empty = resolve_text_color_hex(cfg.text_color_empty)
             if self._vital_slot(
-                tracker, raw, maxval, _BAR_WIDTH, kind, priority, order, now, slots,
+                tracker,
+                raw,
+                maxval,
+                _BAR_WIDTH,
+                kind,
+                priority,
+                order,
+                now,
+                slots,
                 color_override=color,
-                text_fill_color=text_fill, text_empty_color=text_empty,
+                text_fill_color=text_fill,
+                text_empty_color=text_empty,
                 side=side,
             ):
                 needs_reflash = True
@@ -1229,9 +1246,14 @@ class ToolbarRenderer:
         flash_elapsed = tracker.update(raw, now)
         needs_reflash = flash_elapsed >= 0.0
         frags = _vital_bar(
-            raw, maxval, width, kind,
-            flash_elapsed=flash_elapsed, color_override=color_override,
-            text_fill_color=text_fill_color, text_empty_color=text_empty_color,
+            raw,
+            maxval,
+            width,
+            kind,
+            flash_elapsed=flash_elapsed,
+            color_override=color_override,
+            text_fill_color=text_fill_color,
+            text_empty_color=text_empty_color,
         )
         frags_w = sum(_wcswidth(t) for _, t in frags)
         slots.append(
@@ -1245,8 +1267,13 @@ class ToolbarRenderer:
                 label="",
                 growable=True,
                 grow_params=(
-                    raw, maxval, kind, flash_elapsed, color_override,
-                    text_fill_color, text_empty_color,
+                    raw,
+                    maxval,
+                    kind,
+                    flash_elapsed,
+                    color_override,
+                    text_fill_color,
+                    text_empty_color,
                 ),
             )
         )
@@ -1287,13 +1314,11 @@ class ToolbarRenderer:
         """Append the right-side slot (walk mode, autoreply, or room name)."""
         if randomwalk_active:
             self._travel_bar_slot(
-                self.ctx.randomwalk_current, self.ctx.randomwalk_total,
-                24, "randomwalk", slots,
+                self.ctx.randomwalk_current, self.ctx.randomwalk_total, 24, "randomwalk", slots
             )
         elif discover_active:
             self._travel_bar_slot(
-                self.ctx.discover_current, self.ctx.discover_total,
-                20, "discover", slots,
+                self.ctx.discover_current, self.ctx.discover_total, 20, "discover", slots
             )
         elif ar_active:
             idx = getattr(engine, "exclusive_rule_index", None)
@@ -1336,7 +1361,7 @@ class ToolbarRenderer:
         from .progressbars import TRAVEL_BAR_NAME, bar_color_at, resolve_text_color_hex
 
         travel_cfg = None
-        for cfg in (self.ctx.progressbar_configs or []):
+        for cfg in self.ctx.progressbar_configs or []:
             if cfg.name == TRAVEL_BAR_NAME or (cfg.name and not cfg.gmcp_package):
                 travel_cfg = cfg
                 break
@@ -1358,9 +1383,13 @@ class ToolbarRenderer:
             side = getattr(travel_cfg, "side", "right")
 
         mode_frags = _vital_bar(
-            cur, tot, width, kind,
+            cur,
+            tot,
+            width,
+            kind,
             color_override=color_override,
-            text_fill_color=text_fill, text_empty_color=text_empty,
+            text_fill_color=text_fill,
+            text_empty_color=text_empty,
         )
         mode_w = sum(_wcswidth(t) for _, t in mode_frags)
         slots.append(
@@ -1373,8 +1402,7 @@ class ToolbarRenderer:
                 min_width=0,
                 label="",
                 growable=True,
-                grow_params=(cur, tot, kind, -1.0, color_override,
-                             text_fill, text_empty),
+                grow_params=(cur, tot, kind, -1.0, color_override, text_fill, text_empty),
             )
         )
 
@@ -1466,10 +1494,11 @@ class ToolbarRenderer:
     def restore_cursor(
         self, bt: "blessed.Terminal", row: int, col: int, is_autoreply_bg: bool
     ) -> None:
-        """Show the cursor at *row*, *col*, using the stoplight glyph if animating.
+        """
+        Show the cursor at *row*, *col*, using the stoplight glyph if animating.
 
-        Picks the appropriate style and OSC color for normal or autoreply
-        background, then makes the terminal cursor visible.
+        Picks the appropriate style and OSC color for normal or autoreply background, then makes the
+        terminal cursor visible.
         """
         if self.cursor_light(bt, row, col, is_autoreply_bg):
             return
@@ -1508,10 +1537,7 @@ class ToolbarRenderer:
 
                 hint = _activity_hint(engine, bt.width)
                 prog = _until_progress(engine)
-                bg = (
-                    _STYLE_AUTOREPLY["bg_sgr"] if is_ar_bg
-                    else _STYLE_NORMAL["bg_sgr"]
-                )
+                bg = _STYLE_AUTOREPLY["bg_sgr"] if is_ar_bg else _STYLE_NORMAL["bg_sgr"]
                 if cq is not None:
                     cursor_col = _render_command_queue(
                         cq,
@@ -1554,10 +1580,7 @@ class ToolbarRenderer:
                     if hint_split != self._last_hint_split:
                         self._last_hint_split = hint_split
                         col = bt.width - hint_w
-                        bg = (
-                            _STYLE_AUTOREPLY["bg_sgr"] if is_ar_bg
-                            else _STYLE_NORMAL["bg_sgr"]
-                        )
+                        bg = _STYLE_AUTOREPLY["bg_sgr"] if is_ar_bg else _STYLE_NORMAL["bg_sgr"]
                         self.out.write(bt.move_yx(input_row, col).encode())
                         _write_hint(hint, self.out, bt, progress=prog, bg_sgr=bg)
                     if prog is not None:

--- a/telix/client_repl_travel.py
+++ b/telix/client_repl_travel.py
@@ -201,10 +201,7 @@ async def _fast_travel(
                 if ctx.discover_active:
                     prefix = f"AUTODISCOVER [{ctx.discover_current}]: "
                 elif ctx.randomwalk_active:
-                    prefix = (
-                        f"RANDOMWALK [{ctx.randomwalk_current}"
-                        f"/{ctx.randomwalk_total}]: "
-                    )
+                    prefix = f"RANDOMWALK [{ctx.randomwalk_current}" f"/{ctx.randomwalk_total}]: "
                 if attempt == 0:
                     log.info("%s [%d/%d] %s", mode, step_idx + 1, len(steps), direction)
                     if echo_fn is not None:
@@ -804,8 +801,7 @@ async def _randomwalk(
     def _count_filled() -> int:
         """Sum visits across reachable rooms, capped at visit_level per room."""
         if not reachable:
-            return sum(min(int(v), visit_level) for v in walk_counts.values()
-                       if v != float("inf"))
+            return sum(min(int(v), visit_level) for v in walk_counts.values() if v != float("inf"))
         return sum(min(int(walk_counts.get(r, 0)), visit_level) for r in reachable)
 
     try:

--- a/telix/macros.py
+++ b/telix/macros.py
@@ -51,10 +51,16 @@ def _parse_entries(entries: list[dict[str, str]]) -> list[Macro]:
         last_used = str(entry.get("last_used", ""))
         toggle = bool(entry.get("toggle", False))
         toggle_text = str(entry.get("toggle_text", ""))
-        macros.append(Macro(
-            key=key, text=text, enabled=enabled, last_used=last_used,
-            toggle=toggle, toggle_text=toggle_text,
-        ))
+        macros.append(
+            Macro(
+                key=key,
+                text=text,
+                enabled=enabled,
+                last_used=last_used,
+                toggle=toggle,
+                toggle_text=toggle_text,
+            )
+        )
     return macros
 
 
@@ -153,9 +159,7 @@ def build_macro_dispatch(macros: list[Macro], ctx: Any, log: logging.Logger) -> 
             _m.last_used = datetime.now(timezone.utc).isoformat()
             if hasattr(ctx, "mark_macros_dirty"):
                 ctx.mark_macros_dirty()
-            task = asyncio.ensure_future(
-                _repl.execute_macro_commands(_text, ctx, log)
-            )
+            task = asyncio.ensure_future(_repl.execute_macro_commands(_text, ctx, log))
 
             def _on_done(t: "asyncio.Task[None]") -> None:
                 if not t.cancelled() and t.exception() is not None:

--- a/telix/progressbars.py
+++ b/telix/progressbars.py
@@ -73,12 +73,27 @@ def get_theme_colors() -> dict[str, str]:
             cs = app.current_theme
             if cs is not None:
                 return {
-                    k: v for k, v in sorted(cs.generate().items())
-                    if not any(x in k for x in (
-                        "cursor", "button", "footer", "style", "hover",
-                        "disabled", "scrollbar", "input", "link", "text-",
-                        "markdown", "tooltip",
-                    )) and len(v) in (7, 9) and v.startswith("#")
+                    k: v
+                    for k, v in sorted(cs.generate().items())
+                    if not any(
+                        x in k
+                        for x in (
+                            "cursor",
+                            "button",
+                            "footer",
+                            "style",
+                            "hover",
+                            "disabled",
+                            "scrollbar",
+                            "input",
+                            "link",
+                            "text-",
+                            "markdown",
+                            "tooltip",
+                        )
+                    )
+                    and len(v) in (7, 9)
+                    and v.startswith("#")
                 }
     except Exception:
         pass
@@ -88,12 +103,27 @@ def get_theme_colors() -> dict[str, str]:
 
         cs = BUILTIN_THEMES["textual-dark"].to_color_system()
         return {
-            k: v for k, v in sorted(cs.generate().items())
-            if not any(x in k for x in (
-                "cursor", "button", "footer", "style", "hover",
-                "disabled", "scrollbar", "input", "link", "text-",
-                "markdown", "tooltip",
-            )) and len(v) in (7, 9) and v.startswith("#")
+            k: v
+            for k, v in sorted(cs.generate().items())
+            if not any(
+                x in k
+                for x in (
+                    "cursor",
+                    "button",
+                    "footer",
+                    "style",
+                    "hover",
+                    "disabled",
+                    "scrollbar",
+                    "input",
+                    "link",
+                    "text-",
+                    "markdown",
+                    "tooltip",
+                )
+            )
+            and len(v) in (7, 9)
+            and v.startswith("#")
         }
     except Exception:
         return {}
@@ -182,7 +212,7 @@ def detect_progressbars(gmcp_data: dict[str, Any]) -> list[BarConfig]:
             color_path="shortest",
             display_order=0,
             side="right",
-        ),
+        )
     ]
     seen: set[tuple[str, str, str]] = set()
 

--- a/telix/tests/test_client_repl.py
+++ b/telix/tests/test_client_repl.py
@@ -963,11 +963,7 @@ def _dispatch_hooks(**overrides: Any) -> "tuple[Any, list[str], list[str]]":
     echoed: list[str] = []
     status: list[str] = []
     defaults = dict(
-        ctx=types.SimpleNamespace(
-            gmcp_data={},
-            captures={},
-            autoreply_engine=None,
-        ),
+        ctx=types.SimpleNamespace(gmcp_data={}, captures={}, autoreply_engine=None),
         log=__import__("logging").getLogger("test"),
         wait_fn=None,
         send_fn=sent.append,
@@ -984,11 +980,7 @@ def _dispatch_hooks(**overrides: Any) -> "tuple[Any, list[str], list[str]]":
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "cmd, expected_result",
-    [
-        ("`delay 0ms`", "HANDLED"),
-        ("`delay 1s`", "HANDLED"),
-        ("`delay 500ms`", "HANDLED"),
-    ],
+    [("`delay 0ms`", "HANDLED"), ("`delay 1s`", "HANDLED"), ("`delay 500ms`", "HANDLED")],
 )
 async def test_dispatch_one_delay(
     monkeypatch: pytest.MonkeyPatch, cmd: str, expected_result: str
@@ -1041,7 +1033,7 @@ async def test_dispatch_one_when_pass() -> None:
             gmcp_data={"Char.Vitals": {"hp": "80", "maxhp": "100"}},
             captures={},
             autoreply_engine=None,
-        ),
+        )
     )
     result = await dispatch_one("`when HP%>=50`", 0, 0, frozenset(), hooks)
     assert result is StepResult.HANDLED
@@ -1059,7 +1051,7 @@ async def test_dispatch_one_when_fail() -> None:
             gmcp_data={"Char.Vitals": {"hp": "20", "maxhp": "100"}},
             captures={},
             autoreply_engine=None,
-        ),
+        )
     )
     result = await dispatch_one("`when HP%>=50`", 0, 0, frozenset(), hooks)
     assert result is StepResult.ABORT
@@ -1246,12 +1238,12 @@ from telix.client_repl_render import (  # noqa: E402
     DURATION,
     IDLE_RGB,
     PEAK_RED,
+    _ELLIPSIS,
     IDLE_AR_RGB,
     PEAK_YELLOW,
     ActivityDot,
     lerp_rgb,
     _activity_hint,
-    _ELLIPSIS,
 )
 
 

--- a/telix/tests/test_macros.py
+++ b/telix/tests/test_macros.py
@@ -10,7 +10,7 @@ import logging
 import pytest
 
 # local
-from telix.macros import Macro, build_macro_dispatch, load_macros, save_macros
+from telix.macros import Macro, load_macros, save_macros, build_macro_dispatch
 
 _SK = "test.host:23"
 
@@ -128,19 +128,25 @@ def test_toggle_macro_roundtrip(tmp_path):
 
 def test_toggle_default_state_false(tmp_path):
     fp = tmp_path / "macros.json"
-    fp.write_text(json.dumps({
-        _SK: {"macros": [
-            {"key": "KEY_F5", "text": "on", "toggle": True, "toggle_text": "off"},
-        ]}
-    }))
+    fp.write_text(
+        json.dumps(
+            {
+                _SK: {
+                    "macros": [
+                        {"key": "KEY_F5", "text": "on", "toggle": True, "toggle_text": "off"}
+                    ]
+                }
+            }
+        )
+    )
     loaded = load_macros(str(fp), _SK)
     assert loaded[0].toggle_state is False
 
 
 def test_toggle_dispatch_alternates():
     pytest.importorskip("blessed")
-    import asyncio
     import types
+    import asyncio
     from unittest.mock import patch
 
     sent: list[str] = []

--- a/telix/tests/test_progressbars.py
+++ b/telix/tests/test_progressbars.py
@@ -11,8 +11,8 @@ import pytest
 
 # local
 from telix.progressbars import (
-    BarConfig,
     TRAVEL_BAR_NAME,
+    BarConfig,
     bar_color_at,
     load_progressbars,
     save_progressbars,
@@ -132,11 +132,27 @@ def test_round_trip(tmp_path):
     path = str(tmp_path / "pb.json")
     bars = [
         BarConfig(
-            "HP", "Char.Vitals", "hp", "maxhp", True, "theme", "green", "red", "shortest",
+            "HP",
+            "Char.Vitals",
+            "hp",
+            "maxhp",
+            True,
+            "theme",
+            "green",
+            "red",
+            "shortest",
             display_order=0,
         ),
         BarConfig(
-            "MP", "Char.Vitals", "mp", "maxmp", True, "custom", "blue", "gold1", "longest",
+            "MP",
+            "Char.Vitals",
+            "mp",
+            "maxmp",
+            True,
+            "custom",
+            "blue",
+            "gold1",
+            "longest",
             display_order=1,
         ),
     ]
@@ -356,8 +372,11 @@ def test_side_left_omitted_from_json(tmp_path):
 
 def test_load_json_without_side_defaults_left(tmp_path):
     path = str(tmp_path / "pb.json")
-    data = {"m:1": {"bars": [{"name": "HP", "gmcp_package": "V",
-            "value_field": "hp", "max_field": "mhp"}]}}
+    data = {
+        "m:1": {
+            "bars": [{"name": "HP", "gmcp_package": "V", "value_field": "hp", "max_field": "mhp"}]
+        }
+    }
     with open(path, "w") as f:
         json.dump(data, f)
     loaded = load_progressbars(path, "m:1")

--- a/telix/tests/test_subprocess_errors.py
+++ b/telix/tests/test_subprocess_errors.py
@@ -53,7 +53,7 @@ class TestLaunchTuiEditorError:
         from telix.client_repl_dialogs import _launch_tui_editor
 
         fail_result = subprocess.CompletedProcess(
-            args=[], returncode=1, stderr=b"NameError: something\n",
+            args=[], returncode=1, stderr=b"NameError: something\n"
         )
         monkeypatch.setattr("subprocess.run", lambda cmd, check=False, **kw: fail_result)
         monkeypatch.setattr("os.path.exists", lambda p: False)
@@ -120,6 +120,7 @@ class TestLaunchUnifiedEditor:
     @pytest.mark.usefixtures("_stub_terminal")
     def test_subprocess_receives_json_params(self, monkeypatch: Any) -> None:
         import json
+
         from telix.client_repl_dialogs import _launch_unified_editor
 
         captured_cmd: list[list[str]] = []
@@ -156,6 +157,7 @@ class TestLaunchUnifiedEditor:
     @pytest.mark.usefixtures("_stub_terminal")
     def test_all_tabs_pass_correct_initial_tab(self, monkeypatch: Any) -> None:
         import json
+
         from telix.client_repl_dialogs import _launch_unified_editor
 
         captured_tabs: list[str] = []
@@ -185,7 +187,13 @@ class TestLaunchUnifiedEditor:
             _launch_unified_editor(tab, ctx)
 
         assert captured_tabs == [
-            "help", "highlights", "rooms", "macros", "autoreplies", "captures", "bars",
+            "help",
+            "highlights",
+            "rooms",
+            "macros",
+            "autoreplies",
+            "captures",
+            "bars",
         ]
 
     @pytest.mark.usefixtures("_stub_terminal")
@@ -258,21 +266,18 @@ class TestLaunchUnifiedEditor:
     @pytest.mark.usefixtures("_stub_terminal")
     def test_handles_fast_travel(self, monkeypatch: Any) -> None:
         import asyncio
+
         from telix.client_repl_dialogs import _launch_unified_editor
 
         ok_result = subprocess.CompletedProcess(args=[], returncode=0)
         monkeypatch.setattr("subprocess.run", lambda cmd, check=False, **kw: ok_result)
         monkeypatch.setattr("os.path.exists", lambda p: False)
-        monkeypatch.setattr(
-            "telix.rooms.read_fasttravel", lambda p: (["north", "east"], False)
-        )
+        monkeypatch.setattr("telix.rooms.read_fasttravel", lambda p: (["north", "east"], False))
 
         async def fake_fast_travel(steps, ctx, log, noreply=False):
             pass
 
-        monkeypatch.setattr(
-            "telix.client_repl_travel._fast_travel", fake_fast_travel
-        )
+        monkeypatch.setattr("telix.client_repl_travel._fast_travel", fake_fast_travel)
 
         written: list[str] = []
         monkeypatch.setattr(
@@ -300,9 +305,7 @@ class TestLaunchChatViewerError:
     def test_error_prompt_on_nonzero(self, monkeypatch: Any) -> None:
         from telix.client_repl_dialogs import _launch_chat_viewer
 
-        fail_result = subprocess.CompletedProcess(
-            args=[], returncode=1, stderr=b"Error\n",
-        )
+        fail_result = subprocess.CompletedProcess(args=[], returncode=1, stderr=b"Error\n")
         monkeypatch.setattr("subprocess.run", lambda cmd, check=False, **kw: fail_result)
 
         written: list[str] = []
@@ -326,9 +329,7 @@ class TestLaunchRoomBrowserError:
     def test_error_prompt_on_nonzero(self, monkeypatch: Any) -> None:
         from telix.client_repl_dialogs import _launch_room_browser
 
-        fail_result = subprocess.CompletedProcess(
-            args=[], returncode=1, stderr=b"Error\n",
-        )
+        fail_result = subprocess.CompletedProcess(args=[], returncode=1, stderr=b"Error\n")
         monkeypatch.setattr("subprocess.run", lambda cmd, check=False, **kw: fail_result)
         monkeypatch.setattr("telix.rooms.read_fasttravel", lambda p: ([], False))
 


### PR DESCRIPTION
## Summary

- Automated formatting pass with `black` and `isort` across existing source and test modules
- No functional changes -- purely whitespace and import ordering

## Files Changed (12)

- `telix/autoreply.py`
- `telix/client_repl.py`
- `telix/client_repl_commands.py`
- `telix/client_repl_dialogs.py`
- `telix/client_repl_render.py`
- `telix/client_repl_travel.py`
- `telix/macros.py`
- `telix/progressbars.py`
- `telix/tests/test_client_repl.py`
- `telix/tests/test_macros.py`
- `telix/tests/test_progressbars.py`
- `telix/tests/test_subprocess_errors.py`

## Testing

All 812 tests pass on py313.

## Disclosure

This PR was authored with the assistance of an AI coding agent (Claude, via OpenCode). All changes were reviewed and tested by a human before submission.