### PR TITLE
feat: TUI integration for WebSocket protocol selection

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -28,13 +28,16 @@ Architecture
 ------------
 
 telix is a TUI telnet and MUD client layered on top of `telnetlib3
-<https://github.com/jquast/telnetlib3>`_::
+<https://github.com/jquast/telnetlib3>`_ and `websockets
+<https://github.com/python-websockets/websockets>`_::
 
     telix  -->  telnetlib3  -->  wcwidth
       |
+      +--> websockets
+      |
       +--> blessed, textual
 
-**telnetlib3 must never import from telix.** Use `writer.ctx` session context or callback hooks.
+**telnetlib3 must never import from telix.** Use ``writer.ctx`` session context or callback hooks.
 
 Module map::
 
@@ -42,6 +45,9 @@ Module map::
     ├── main.py                 CLI entry (TUI or direct connect)
     ├── session_context.py      Per-connection mutable state
     ├── client_shell.py         Shell callback (drop-in for telnetlib3)
+    │
+    ├── ws_transport.py         WebSocket reader/writer adapters
+    ├── ws_client.py            WebSocket connection launcher (telix-ws)
     │
     ├── client_repl.py          blessed LineEditor REPL event loop
     ├── client_repl_render.py   Toolbar / status line rendering
@@ -137,11 +143,18 @@ telix connects to a remote host by calling ``telnetlib3.open_connection()``
 with ``--shell=telix.client_shell.telix_client_shell``, a drop-in
 replacement for ``telnetlib3.client_shell.telnet_client_shell``.
 
-Every ``TelnetWriter`` has a ``.ctx`` attribute that defaults to a
-``TelnetSessionContext``.  telix's ``SessionContext`` subclasses
-``TelnetSessionContext``, adding MUD-specific state (rooms, macros,
-highlights, chat, etc.).  The shell callback creates a ``SessionContext``
-and assigns it to ``writer.ctx``.
+For WebSocket connections, ``ws_client.py`` connects via
+``websockets.connect()`` using the ``gmcp.mudstandards.org`` subprotocol
+and calls ``ws_client_shell(reader, writer)`` with adapter objects
+(``WebSocketReader``/``WebSocketWriter``) that present the same
+interface as telnetlib3's reader/writer pair.
+
+Every ``TelnetWriter`` (or ``WebSocketWriter``) has a ``.ctx``
+attribute that defaults to a ``TelnetSessionContext``.  telix's
+``SessionContext`` subclasses ``TelnetSessionContext``, adding
+MUD-specific state (rooms, macros, highlights, chat, etc.).  The
+shell callback creates a ``SessionContext`` and assigns it to
+``writer.ctx``.
 
 telix's ``SessionContext`` also provides ``captures`` (a flat
 ``dict[str, int]`` of captured variables) and ``capture_log`` (a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "telix"
 version = "0.0.1"
-description = "A TUI telnet and MUD client"
+description = "A TUI telnet, WebSocket, and MUD client"
 readme = "README.rst"
 license = "ISC"
 license-files = ["LICENSE.txt"]
@@ -14,6 +14,7 @@ authors = [
 ]
 keywords = [
     "telnet",
+    "websocket",
     "mud",
     "tui",
     "client",
@@ -46,6 +47,7 @@ dependencies = [
     "blessed>=1.32,<2",
     "textual>=0.44,<1",
     "wcwidth>=0.6.0,<1",
+    "websockets>=14.0",
 ]
 
 [project.optional-dependencies]
@@ -57,6 +59,7 @@ docs = [
 
 [project.scripts]
 telix = "telix.main:main"
+telix-ws = "telix.ws_client:main"
 
 [project.urls]
 Homepage = "https://github.com/jquast/telix"

--- a/telix/client_shell.py
+++ b/telix/client_shell.py
@@ -6,6 +6,9 @@ Provides :func:`telix_client_shell`, a drop-in replacement for
 :class:`~telix.session_context.SessionContext`, loads per-session configs
 (macros, autoreplies, highlights, chat, rooms), and alternates between
 REPL and raw event loops based on telnet negotiation state.
+
+Also provides :func:`ws_client_shell` for WebSocket connections using
+the ``gmcp.mudstandards.org`` wire format.
 """
 
 from __future__ import annotations
@@ -30,32 +33,37 @@ from telnetlib3.stream_writer import TelnetWriter, TelnetWriterUnicode
 # local
 from . import _paths
 from .client_repl import repl_event_loop
+from .ws_transport import WebSocketReader, WebSocketWriter
 from .session_context import SessionContext
 
 log = logging.getLogger(__name__)
 
-__all__ = ("telix_client_shell",)
+__all__ = ("telix_client_shell", "ws_client_shell")
 
 
-def _build_session_key(writer: Union[TelnetWriter, TelnetWriterUnicode]) -> str:
+def _build_session_key(writer: Union[TelnetWriter, TelnetWriterUnicode, WebSocketWriter]) -> str:
     """
     Derive ``host:port`` session key from CLI arguments or peername.
 
-    Prefers the original hostname from ``sys.argv`` over the resolved IP
-    from :func:`socket.getpeername`, so that session-specific files
-    (history, rooms, macros, etc.) are keyed by the human-readable
-    hostname used to connect.
+    For telnet writers, prefers the original hostname from ``sys.argv``
+    over the resolved IP from :func:`socket.getpeername`, so that
+    session-specific files (history, rooms, macros, etc.) are keyed by
+    the human-readable hostname used to connect.
+
+    For WebSocket writers, falls through directly to peername since the
+    hostname is already set by the WebSocket client.
     """
-    import sys
+    if not isinstance(writer, WebSocketWriter):
+        import sys
 
-    try:
-        from telnetlib3.client import _get_argument_parser
+        try:
+            from telnetlib3.client import _get_argument_parser
 
-        args = _get_argument_parser().parse_known_args(sys.argv[1:])[0]
-        if args.host:
-            return f"{args.host}:{args.port}"
-    except (SystemExit, Exception):
-        pass
+            args = _get_argument_parser().parse_known_args(sys.argv[1:])[0]
+            if args.host:
+                return f"{args.host}:{args.port}"
+        except (SystemExit, Exception):
+            pass
     peername = writer.get_extra_info("peername")
     if peername:
         return f"{peername[0]}:{peername[1]}"
@@ -122,7 +130,7 @@ def _load_configs(ctx: SessionContext) -> None:
     ctx.on_chat_channels = lambda data: setattr(ctx, "chat_channels", data)
 
     # rooms
-    from .rooms import rooms_path, current_room_path, RoomStore, write_current_room
+    from .rooms import RoomStore, rooms_path, current_room_path, write_current_room
 
     rooms_file = rooms_path(session_key)
     ctx.rooms_file = rooms_file
@@ -306,3 +314,77 @@ async def telix_client_shell(
             break
 
         ctx.close()
+
+
+async def ws_client_shell(reader: WebSocketReader, writer: WebSocketWriter) -> None:
+    """
+    Telix client shell for WebSocket connections.
+
+    Simpler counterpart to :func:`telix_client_shell` -- WebSocket
+    connections are always line-mode (no raw/kludge switching), so this
+    function creates a :class:`SessionContext`, loads configs, wires GMCP
+    dispatch, and runs a single pass of the REPL event loop.
+
+    The pseudo-prompt signal (GA/EOR) is fired by the receive loop in
+    :mod:`~telix.ws_client` after each BINARY frame delivery, giving the
+    REPL the same prompt boundary as telnet.
+
+    :param reader: :class:`WebSocketReader` fed by the receive loop.
+    :param writer: :class:`WebSocketWriter` wrapping the WebSocket connection.
+    """
+    # 1. Build SessionContext and attach to writer.
+    session_key = _build_session_key(writer)
+    ctx = SessionContext(session_key=session_key)
+    ctx.writer = writer
+    ctx.repl_enabled = True
+    writer.ctx = ctx
+
+    # 2. Load per-session configs.
+    _load_configs(ctx)
+
+    # 3. Wire GMCP dispatch (no base callback -- WebSocket has none).
+    from .ws_transport import _GMCP
+
+    def _on_gmcp(package: str, data: Any) -> None:
+        if package == "Comm.Channel.Text":
+            if ctx.on_chat_text is not None:
+                ctx.on_chat_text(data)
+        elif package == "Comm.Channel.List":
+            if ctx.on_chat_channels is not None:
+                ctx.on_chat_channels(data)
+        elif package == "Room.Info":
+            if ctx.on_room_info is not None:
+                ctx.on_room_info(data)
+
+    writer.set_ext_callback(_GMCP, _on_gmcp)
+
+    keyboard_escape = "\x1d"
+
+    # Terminal / repl_event_loop / _flush_color_filter are typed for
+    # TelnetWriter but accept any duck-compatible writer at runtime.
+    with Terminal(telnet_writer=writer) as tty_shell:  # type: ignore[arg-type]
+        linesep = "\n"
+        stdout = await tty_shell.make_stdout()
+        tty_shell.setup_winch()
+
+        from telnetlib3 import accessories
+
+        escape_name = accessories.name_unicode(keyboard_escape)
+        banner_sep = "\r\n" if tty_shell._istty else linesep
+        stdout.write(f"Escape character is '{escape_name}'.{banner_sep}".encode())
+
+        # WebSocket is always line-mode: run REPL once (no raw loop).
+        if tty_shell._istty:
+            await repl_event_loop(
+                reader,  # type: ignore[arg-type]
+                writer,  # type: ignore[arg-type]
+                tty_shell,
+                stdout,
+                history_file=ctx.history_file,
+            )
+
+        _flush_color_filter(writer, stdout)  # type: ignore[arg-type]
+        stdout.write(f"\033[m{linesep}Connection closed.{linesep}".encode())
+        tty_shell.cleanup_winch()
+
+    ctx.close()

--- a/telix/client_tui.py
+++ b/telix/client_tui.py
@@ -68,9 +68,7 @@ def _read_primary_selection() -> str:
     """Read text from the X11/Wayland primary selection via external helper."""
     for cmd in _PRIMARY_PASTE_COMMANDS:
         try:
-            result = subprocess.run(
-                cmd, capture_output=True, timeout=2, check=False,
-            )
+            result = subprocess.run(cmd, capture_output=True, timeout=2, check=False)
             if result.returncode == 0:
                 return result.stdout.decode("utf-8", errors="replace")
         except FileNotFoundError:
@@ -227,7 +225,7 @@ def _build_tooltips() -> dict[str, str]:
 @dataclass
 class SessionConfig:
     """
-    Persistent configuration for a single telnet session.
+    Persistent configuration for a single session.
 
     Field defaults mirror the CLI defaults in
     :func:`telnetlib3.client._get_argument_parser`.
@@ -238,8 +236,10 @@ class SessionConfig:
     last_connected: str = ""
 
     # Connection
+    protocol: str = "telnet"  # "telnet" or "websocket"
     host: str = ""
     port: int = 23
+    ws_path: str = ""  # path appended to WebSocket URL (e.g. "/ws")
     ssl: bool = False
     ssl_cafile: str = ""
     ssl_no_verify: bool = False
@@ -349,10 +349,36 @@ _CMD_NEG_BOOL_FLAGS: list[tuple[str, str, bool]] = [("ice_colors", "--no-ice-col
 
 def build_command(config: SessionConfig) -> list[str]:
     """
-    Build ``telnetlib3-client`` CLI arguments from *config*.
+    Build subprocess CLI arguments from *config*.
 
+    For telnet sessions, builds ``telnetlib3-client`` arguments.
+    For websocket sessions, builds ``telix-ws`` arguments.
     Only emits flags that differ from the CLI defaults.
     """
+    if config.protocol == "websocket":
+        return _build_ws_command(config)
+    return _build_telnet_command(config)
+
+
+def _build_ws_command(config: SessionConfig) -> list[str]:
+    """Build ``telix-ws`` CLI arguments from *config*."""
+    scheme = "wss" if config.ssl else "ws"
+    default_port = 443 if config.ssl else 80
+    if config.port == default_port:
+        url = f"{scheme}://{config.host}"
+    else:
+        url = f"{scheme}://{config.host}:{config.port}"
+    if config.ws_path:
+        path = config.ws_path if config.ws_path.startswith("/") else f"/{config.ws_path}"
+        url += path
+    cmd = [sys.executable, "-c", "from telix.ws_client import main; main()", url]
+    if config.no_repl:
+        cmd.extend(["--shell", "telix.client_shell.ws_client_shell"])
+    return cmd
+
+
+def _build_telnet_command(config: SessionConfig) -> list[str]:
+    """Build ``telnetlib3-client`` CLI arguments from *config*."""
     cmd = [
         sys.executable,
         "-c",
@@ -392,7 +418,7 @@ def build_command(config: SessionConfig) -> list[str]:
 
     for attr, flag in (("always_will", "--always-will"), ("always_do", "--always-do")):
         for opt in getattr(config, attr).split(","):
-            if (opt := opt.strip()):
+            if opt := opt.strip():
                 cmd.extend([flag, opt])
 
     return cmd
@@ -501,6 +527,8 @@ class SessionListScreen(Screen[None]):
     def _flags(cfg: SessionConfig) -> str:
         """Return short flag codes summarizing non-default session options."""
         parts: list[str] = []
+        if cfg.protocol == "websocket":
+            parts.append("ws")
         if cfg.ssl:
             parts.append("ssl")
         if cfg.mode == "raw":
@@ -842,6 +870,18 @@ class SessionEditScreen(Screen[SessionConfig | None]):  # type: ignore[misc]
     #port {
         max-width: 14;
     }
+    #ws-path-row {
+        display: none;
+    }
+    #ws-path-row.visible {
+        display: block;
+    }
+    #protocol-radio {
+        height: auto;
+    }
+    #protocol-row {
+        height: auto;
+    }
     #ssl-compress-row {
         height: auto;
     }
@@ -850,10 +890,16 @@ class SessionEditScreen(Screen[SessionConfig | None]):  # type: ignore[misc]
         max-width: 17;
         height: auto;
     }
+    #server-type-col.ws-hidden {
+        display: none;
+    }
     #compression-col {
         width: auto;
         max-width: 19;
         height: auto;
+    }
+    #compression-col.ws-hidden {
+        display: none;
     }
     #ssl-timeout-col {
         width: 1fr;
@@ -951,6 +997,7 @@ class SessionEditScreen(Screen[SessionConfig | None]):  # type: ignore[misc]
 
     def _compose_connection_tab(self, cfg: SessionConfig) -> ComposeResult:
         """Yield widgets for the Connection tab pane."""
+        _ws = cfg.protocol == "websocket"
         if not self._is_defaults:
             yield self._field_row(
                 "Name",
@@ -961,11 +1008,27 @@ class SessionEditScreen(Screen[SessionConfig | None]):  # type: ignore[misc]
                     classes="field-input",
                 ),
             )
+            with Horizontal(id="protocol-row"):
+                yield Label("Protocol", classes="field-label")
+                with RadioSet(id="protocol-radio"):
+                    yield RadioButton(
+                        "Telnet", value=cfg.protocol != "websocket", id="proto-telnet"
+                    )
+                    yield RadioButton(
+                        "WebSocket", value=cfg.protocol == "websocket", id="proto-websocket"
+                    )
+            _port_ph = "443" if _ws else "23"
             yield Horizontal(
                 Label("Host:Port", classes="field-label"),
                 Input(value=cfg.host, placeholder="hostname", id="host", classes="field-input"),
                 Static(":", id="host-port-sep"),
-                Input(value=str(cfg.port), placeholder="23", id="port"),
+                Input(value=str(cfg.port), placeholder=_port_ph, id="port"),
+                classes="field-row",
+            )
+            yield Horizontal(
+                Label("WS Path", classes="field-label"),
+                Input(value=cfg.ws_path, id="ws-path", classes="field-input"),
+                id="ws-path-row",
                 classes="field-row",
             )
         with Horizontal(id="ssl-compress-row"):
@@ -975,7 +1038,7 @@ class SessionEditScreen(Screen[SessionConfig | None]):  # type: ignore[misc]
                     yield RadioButton("BBS", id="type-bbs")
                     yield RadioButton("MUD", id="type-mud")
             with Vertical(id="compression-col"):
-                yield Label("MCCP Compression")
+                yield Label("MCCP Compression", id="compression-label")
                 with RadioSet(id="compression-radio"):
                     yield RadioButton(
                         "Passive", value=cfg.compression is None, id="compress-passive"
@@ -1099,7 +1162,7 @@ class SessionEditScreen(Screen[SessionConfig | None]):  # type: ignore[misc]
                 yield Button("Save", variant="success", id="save-btn")
 
     def on_mount(self) -> None:
-        """Apply argparse-derived tooltips to form widgets."""
+        """Apply argparse-derived tooltips and initial widget visibility."""
         tips = _build_tooltips()
         for widget_id, help_text in tips.items():
             try:
@@ -1112,9 +1175,12 @@ class SessionEditScreen(Screen[SessionConfig | None]):  # type: ignore[misc]
             idx = radio_set.pressed_index
             if idx >= 0:
                 radio_set._selected = idx
+        if not self._is_defaults:
+            is_ws = self._config.protocol == "websocket"
+            self._apply_protocol_visibility(is_ws)
 
     def on_radio_set_changed(self, event: RadioSet.Changed) -> None:
-        """Handle radio-set changes for server type and terminal mode."""
+        """Handle radio-set changes for server type, terminal mode, and protocol."""
         if event.radio_set.id == "server-type-radio":
             self._apply_server_type(event.pressed.id)
         elif event.radio_set.id == "mode-radio":
@@ -1122,6 +1188,32 @@ class SessionEditScreen(Screen[SessionConfig | None]):  # type: ignore[misc]
             repl_switch = self.query_one("#use-repl", Switch)
             repl_switch.disabled = is_raw
             self.query_one("#repl-label", Label).set_class(is_raw, "dimmed")
+        elif event.radio_set.id == "protocol-radio":
+            is_ws = event.pressed.id == "proto-websocket"
+            self._apply_protocol_visibility(is_ws)
+
+    def _apply_protocol_visibility(self, is_ws: bool) -> None:
+        """Show/hide and enable/disable widgets based on the selected protocol."""
+        try:
+            self.query_one("#server-type-col").set_class(is_ws, "ws-hidden")
+        except NoMatches:
+            pass
+        try:
+            self.query_one("#compression-col").set_class(is_ws, "ws-hidden")
+        except NoMatches:
+            pass
+        try:
+            self.query_one("#ws-path-row").set_class(is_ws, "visible")
+        except NoMatches:
+            pass
+        try:
+            port_input = self.query_one("#port", Input)
+            port_input.placeholder = "443" if is_ws else "23"
+            cur = _int_val(port_input.value, 0)
+            if cur in (23, 443, 80):
+                port_input.value = "443" if is_ws else "23"
+        except NoMatches:
+            pass
 
     def _select_radio(self, radio_set_id: str, button_id: str) -> None:
         """Select a radio button by deselecting all siblings first."""
@@ -1224,7 +1316,7 @@ class SessionEditScreen(Screen[SessionConfig | None]):  # type: ignore[misc]
                 target = tab_buttons[idx + 1]
             if target is not None:
                 target.focus()
-                if (tab_id := (target.id or "").replace("tabbtn-", "")):
+                if tab_id := (target.id or "").replace("tabbtn-", ""):
                     self._switch_to_tab(tab_id)
                 event.prevent_default()
             elif event.key == "down":
@@ -1292,6 +1384,11 @@ class SessionEditScreen(Screen[SessionConfig | None]):  # type: ignore[misc]
             cfg.name = self.query_one("#name", Input).value.strip()
             cfg.host = self.query_one("#host", Input).value.strip()
             cfg.port = _int_val(self.query_one("#port", Input).value, 23)
+            cfg.ws_path = self.query_one("#ws-path", Input).value.strip()
+            if self.query_one("#proto-websocket", RadioButton).value:
+                cfg.protocol = "websocket"
+            else:
+                cfg.protocol = "telnet"
         else:
             cfg.name = DEFAULTS_KEY
 
@@ -1395,7 +1492,8 @@ class _HelpPane(Vertical):
                 yield Markdown(content, id="help-content")
 
     def update_topic(self, topic: str) -> None:
-        """Replace help content with a different topic.
+        """
+        Replace help content with a different topic.
 
         :param topic: Help topic key (e.g. ``"macro"``, ``"keybindings"``).
         """
@@ -1671,8 +1769,7 @@ class _EditListPane(Vertical):
                 table.focus()
                 event.prevent_default()
                 return
-            if (self.screen.focused is table
-                    and event.key == "up" and table.cursor_row == 0):
+            if self.screen.focused is table and event.key == "up" and table.cursor_row == 0:
                 search_input.focus()
                 event.prevent_default()
                 return
@@ -1758,9 +1855,7 @@ class _EditListPane(Vertical):
             "cancel-form": self._hide_form,
             "save": self._action_save,
             "close": lambda: self._request_close(None),
-            "help": lambda: self.app.push_screen(
-                _CommandHelpScreen(topic=self._prefix)
-            ),
+            "help": lambda: self.app.push_screen(_CommandHelpScreen(topic=self._prefix)),
         }
         handler = handlers.get(suffix)
         if handler:
@@ -1806,10 +1901,7 @@ class _EditListPane(Vertical):
             cmd = f"`travel {room_id}`"
             self._insert_command(cmd)
 
-        kwargs: dict[str, str] = {
-            "rooms_path": rooms_file,
-            "session_key": self._session_key,
-        }
+        kwargs: dict[str, str] = {"rooms_path": rooms_file, "session_key": self._session_key}
         if self._current_room_path:
             kwargs["current_room_file"] = self._current_room_path
         self.app.push_screen(RoomPickerScreen(**kwargs), callback=_on_pick)
@@ -1902,8 +1994,7 @@ class MacroEditPane(_EditListPane):
     """
 
     def __init__(
-        self, path: str, session_key: str = "", rooms_file: str = "",
-        current_room_file: str = "",
+        self, path: str, session_key: str = "", rooms_file: str = "", current_room_file: str = ""
     ) -> None:
         """Initialize macro editor with file path and session key."""
         super().__init__()
@@ -1961,21 +2052,14 @@ class MacroEditPane(_EditListPane):
                         with Horizontal(id="macro-toggle-row", classes="field-row"):
                             yield Label("Toggle:", classes="toggle-label")
                             yield Switch(value=False, id="macro-toggle")
-                        with Horizontal(
-                            id="macro-toggle-text-row", classes="field-row"
-                        ):
+                        with Horizontal(id="macro-toggle-text-row", classes="field-row"):
                             yield Label("Off command", classes="form-label")
                             yield Input(
-                                placeholder="off command with ; separators",
-                                id="macro-toggle-text",
+                                placeholder="off command with ; separators", id="macro-toggle-text"
                             )
                         with Horizontal(classes="field-row"):
-                            yield Button(
-                                "Travel", id="macro-fast-travel", classes="insert-btn"
-                            )
-                            yield Button(
-                                "Return", id="macro-return", classes="insert-btn"
-                            )
+                            yield Button("Travel", id="macro-fast-travel", classes="insert-btn")
+                            yield Button("Return", id="macro-return", classes="insert-btn")
                         with Horizontal(classes="field-row"):
                             yield Button(
                                 "Autodiscover", id="macro-autodiscover", classes="insert-btn"
@@ -2011,8 +2095,7 @@ class MacroEditPane(_EditListPane):
         try:
             macros = load_macros(self._path, self._session_key)
             self._macros = [
-                (m.key, m.text, m.enabled, m.last_used, m.toggle, m.toggle_text)
-                for m in macros
+                (m.key, m.text, m.enabled, m.last_used, m.toggle, m.toggle_text) for m in macros
             ]
         except (ValueError, FileNotFoundError):
             pass
@@ -2049,8 +2132,13 @@ class MacroEditPane(_EditListPane):
         self._refresh_table()
 
     def _show_form(
-        self, key_val: str = "", text_val: str = "", enabled: bool = True,
-        last_used: str = "", toggle: bool = False, toggle_text: str = "",
+        self,
+        key_val: str = "",
+        text_val: str = "",
+        enabled: bool = True,
+        last_used: str = "",
+        toggle: bool = False,
+        toggle_text: str = "",
     ) -> None:
         self._captured_key = key_val
         self._capturing = False
@@ -2094,14 +2182,24 @@ class MacroEditPane(_EditListPane):
         toggle = self.query_one("#macro-toggle", Switch).value
         toggle_text = self.query_one("#macro-toggle-text", Input).value
         lu = self._macros[self._editing_idx][3] if self._editing_idx is not None else ""
-        self._finalize_edit(
-            (key_val, text_val, enabled, lu, toggle, toggle_text), bool(key_val)
-        )
+        self._finalize_edit((key_val, text_val, enabled, lu, toggle, toggle_text), bool(key_val))
 
-    _REPL_RESERVED_KEYS: ClassVar[frozenset[str]] = frozenset({
-        "KEY_F1", "KEY_F3", "KEY_F4", "KEY_F5", "KEY_F6", "KEY_F7",
-        "KEY_F8", "KEY_F9", "KEY_F10", "KEY_F11", "KEY_F18", "KEY_F21",
-    })
+    _REPL_RESERVED_KEYS: ClassVar[frozenset[str]] = frozenset(
+        {
+            "KEY_F1",
+            "KEY_F3",
+            "KEY_F4",
+            "KEY_F5",
+            "KEY_F6",
+            "KEY_F7",
+            "KEY_F8",
+            "KEY_F9",
+            "KEY_F10",
+            "KEY_F11",
+            "KEY_F18",
+            "KEY_F21",
+        }
+    )
 
     @staticmethod
     def _blessed_display(blessed_name: str) -> str:
@@ -2148,9 +2246,7 @@ class MacroEditPane(_EditListPane):
                     blessed_key = "KEY_ALT_" + key.upper()
                     self._finish_capture(blessed_key, "ALT_" + key.upper())
                 else:
-                    self._reject_capture(
-                        f"Rejected: escape+{key} -- use Esc then a letter"
-                    )
+                    self._reject_capture(f"Rejected: escape+{key} -- use Esc then a letter")
                 return
 
             if key == "escape":
@@ -2180,9 +2276,7 @@ class MacroEditPane(_EditListPane):
                     self._finish_capture(blessed_key, "ALT_" + letter.upper())
                     return
 
-            self._reject_capture(
-                f"Rejected: {key} -- use F-keys, Ctrl+key, or Alt+key"
-            )
+            self._reject_capture(f"Rejected: {key} -- use F-keys, Ctrl+key, or Alt+key")
             return
 
         super().on_key(event)
@@ -2222,13 +2316,14 @@ class MacroEditScreen(_EditListScreen):
     """Thin screen wrapper for the macro editor."""
 
     def __init__(
-        self, path: str, session_key: str = "", rooms_file: str = "",
-        current_room_file: str = "",
+        self, path: str, session_key: str = "", rooms_file: str = "", current_room_file: str = ""
     ) -> None:
         super().__init__()
         self._pane = MacroEditPane(
-            path=path, session_key=session_key,
-            rooms_file=rooms_file, current_room_file=current_room_file,
+            path=path,
+            session_key=session_key,
+            rooms_file=rooms_file,
+            current_room_file=current_room_file,
         )
 
 
@@ -2371,12 +2466,8 @@ class AutoreplyEditPane(_EditListPane):
                             yield Button("When", id="autoreply-btn-when", classes="insert-btn")
                             yield Button("Until", id="autoreply-btn-until", classes="insert-btn")
                             yield Button("Delay", id="autoreply-btn-delay", classes="insert-btn")
-                            yield Button(
-                                "Travel", id="autoreply-fast-travel", classes="insert-btn"
-                            )
-                            yield Button(
-                                "Return", id="autoreply-return", classes="insert-btn"
-                            )
+                            yield Button("Travel", id="autoreply-fast-travel", classes="insert-btn")
+                            yield Button("Return", id="autoreply-return", classes="insert-btn")
                         with Horizontal(classes="field-row"):
                             yield Button(
                                 "Autodiscover", id="autoreply-autodiscover", classes="insert-btn"
@@ -2452,13 +2543,18 @@ class AutoreplyEditPane(_EditListPane):
             if q and not self._matches_search(i, q):
                 continue
             self._filtered_indices.append(i)
-            flags = " ".join(filter(None, [
-                "X" if not rule.enabled else "",
-                "A" if rule.always else "",
-                "I" if rule.immediate else "",
-                "C" if rule.case_sensitive else "",
-                "W" if rule.when else "",
-            ]))
+            flags = " ".join(
+                filter(
+                    None,
+                    [
+                        "X" if not rule.enabled else "",
+                        "A" if rule.always else "",
+                        "I" if rule.immediate else "",
+                        "C" if rule.case_sensitive else "",
+                        "W" if rule.when else "",
+                    ],
+                )
+            )
             lf = _relative_time(rule.last_fired) if rule.last_fired else ""
             row_pos = len(self._filtered_indices) - 1
             table.add_row(str(i + 1), rule.pattern, rule.reply, flags.strip(), lf, key=str(row_pos))
@@ -2492,7 +2588,7 @@ class AutoreplyEditPane(_EditListPane):
             expr = when.get(vital, ">99")
             import re as _re
 
-            if (m := _re.match(r"^(>=|<=|>|<|=)(\d+)$", expr)):
+            if m := _re.match(r"^(>=|<=|>|<|=)(\d+)$", expr):
                 cond_vital, cond_op, cond_val = vital, m.group(1), m.group(2)
         self.query_one("#autoreply-cond-vital", Select).value = cond_vital
         self.query_one("#autoreply-cond-op", Select).value = cond_op
@@ -2584,7 +2680,7 @@ class AutoreplyEditScreen(_EditListScreen):
     def __init__(self, path: str, session_key: str = "", select_pattern: str = "") -> None:
         super().__init__()
         self._pane = AutoreplyEditPane(
-            path=path, session_key=session_key, select_pattern=select_pattern,
+            path=path, session_key=session_key, select_pattern=select_pattern
         )
 
 
@@ -2781,13 +2877,18 @@ class HighlightEditPane(_EditListPane):
             if q and not self._matches_search(i, q):
                 continue
             self._filtered_indices.append(i)
-            flags = " ".join(filter(None, [
-                "X" if not rule.enabled else "",
-                "S" if rule.stop_movement else "",
-                "CS" if rule.case_sensitive else "",
-                "M" if rule.multiline else "",
-                "C" if rule.captured else "",
-            ]))
+            flags = " ".join(
+                filter(
+                    None,
+                    [
+                        "X" if not rule.enabled else "",
+                        "S" if rule.stop_movement else "",
+                        "CS" if rule.case_sensitive else "",
+                        "M" if rule.multiline else "",
+                        "C" if rule.captured else "",
+                    ],
+                )
+            )
             row_pos = len(self._filtered_indices) - 1
             table.add_row(str(i + 1), rule.pattern, rule.highlight, flags.strip(), key=str(row_pos))
         self._update_count_label()
@@ -3111,19 +3212,22 @@ class ProgressBarEditPane(_EditListPane):
                         with Horizontal(classes="field-row"):
                             yield Label("Source", classes="form-label")
                             yield Select[str](
-                                [], id="pb-gmcp-select", allow_blank=True,
+                                [],
+                                id="pb-gmcp-select",
+                                allow_blank=True,
                                 prompt="Select source\u2026",
                             )
                         with Horizontal(classes="field-row"):
                             yield Label("Val/Max", classes="form-label")
                             yield Select[str](
-                                [], id="pb-value-select", allow_blank=True,
+                                [],
+                                id="pb-value-select",
+                                allow_blank=True,
                                 prompt="Value field\u2026",
                             )
                             yield Label("", classes="form-gap")
                             yield Select[str](
-                                [], id="pb-max-select", allow_blank=True,
-                                prompt="Max field\u2026",
+                                [], id="pb-max-select", allow_blank=True, prompt="Max field\u2026"
                             )
                         with Horizontal(id="pb-color-row1", classes="field-row"):
                             yield Label("Color Mode", classes="form-label")
@@ -3133,9 +3237,7 @@ class ProgressBarEditPane(_EditListPane):
                             yield Label("", id="pb-color-gap1", classes="form-gap")
                             yield Label("Path", classes="form-label")
                             with RadioSet(id="pb-color-path"):
-                                yield RadioButton(
-                                    "Shortest", id="pb-path-shortest", value=True,
-                                )
+                                yield RadioButton("Shortest", id="pb-path-shortest", value=True)
                                 yield RadioButton("Longest", id="pb-path-longest")
                         with Horizontal(classes="field-row"):
                             yield Label("Side", classes="form-label")
@@ -3266,9 +3368,14 @@ class ProgressBarEditPane(_EditListPane):
         from .progressbars import BarConfig, bar_color_at
 
         cfg = BarConfig(
-            bar.name, bar.gmcp_package, bar.value_field, bar.max_field,
-            color_mode=bar.color_mode, color_name_max=bar.color_name_max,
-            color_name_min=bar.color_name_min, color_path=bar.color_path,
+            bar.name,
+            bar.gmcp_package,
+            bar.value_field,
+            bar.max_field,
+            color_mode=bar.color_mode,
+            color_name_max=bar.color_name_max,
+            color_name_min=bar.color_name_min,
+            color_path=bar.color_path,
         )
         steps = ProgressBarEditPane._SWATCH_STEPS
         swatch = Text()
@@ -3289,15 +3396,21 @@ class ProgressBarEditPane(_EditListPane):
             self._filtered_indices.append(i)
             enabled = "Yes" if bar.enabled else "No"
             display_name = bar.name if len(bar.name) <= 19 else bar.name[:18] + "\u2026"
-            val_f = (bar.value_field if len(bar.value_field) <= 13
-                     else bar.value_field[:12] + "\u2026")
+            val_f = (
+                bar.value_field if len(bar.value_field) <= 13 else bar.value_field[:12] + "\u2026"
+            )
             max_f = bar.max_field if len(bar.max_field) <= 13 else bar.max_field[:12] + "\u2026"
             swatch = self._color_swatch(bar)
             row_pos = len(self._filtered_indices) - 1
             table.add_row(
-                str(i + 1), display_name, bar.gmcp_package,
-                val_f, max_f,
-                enabled, swatch, key=str(row_pos),
+                str(i + 1),
+                display_name,
+                bar.gmcp_package,
+                val_f,
+                max_f,
+                enabled,
+                swatch,
+                key=str(row_pos),
             )
         self._update_count_label()
 
@@ -3350,8 +3463,11 @@ class ProgressBarEditPane(_EditListPane):
         self.query_one(target, RadioButton).value = True
         # Color selects -- populate with theme or custom options
         self._swap_color_options(
-            is_custom, preserve_max=color_name_max, preserve_min=color_name_min,
-            preserve_text_fill=text_color_fill, preserve_text_empty=text_color_empty,
+            is_custom,
+            preserve_max=color_name_max,
+            preserve_min=color_name_min,
+            preserve_text_fill=text_color_fill,
+            preserve_text_empty=text_color_empty,
         )
         # Values already set by _swap_color_options with proper fallbacks.
         # Color path
@@ -3387,9 +3503,7 @@ class ProgressBarEditPane(_EditListPane):
         )
         text_color_fill = self._get_select_value("#pb-text-min", "auto")
         text_color_empty = self._get_select_value("#pb-text-max", "auto")
-        side = (
-            "right" if self.query_one("#pb-side-right", RadioButton).value else "left"
-        )
+        side = "right" if self.query_one("#pb-side-right", RadioButton).value else "left"
         order = 0
         if self._editing_idx is not None:
             order = self._bars[self._editing_idx].display_order
@@ -3489,14 +3603,16 @@ class ProgressBarEditPane(_EditListPane):
         color_mode = self._get_color_mode()
         max_c = self._get_select_value("#pb-color-max", "success")
         min_c = self._get_select_value("#pb-color-min", "error")
-        path = (
-            "longest"
-            if self.query_one("#pb-path-longest", RadioButton).value
-            else "shortest"
-        )
+        path = "longest" if self.query_one("#pb-path-longest", RadioButton).value else "shortest"
         cfg = BarConfig(
-            name, "", "", "", color_mode=color_mode,
-            color_name_max=max_c, color_name_min=min_c, color_path=path,
+            name,
+            "",
+            "",
+            "",
+            color_mode=color_mode,
+            color_name_max=max_c,
+            color_name_min=min_c,
+            color_path=path,
         )
 
         text_fill_val = self._get_select_value("#pb-text-min", "auto")
@@ -3508,8 +3624,13 @@ class ProgressBarEditPane(_EditListPane):
         kind = name.lower()
         color = bar_color_at(fraction, cfg)
         fragments = _vital_bar(
-            cur, mx, bar_w, kind, color_override=color,
-            text_fill_color=text_fill, text_empty_color=text_empty,
+            cur,
+            mx,
+            bar_w,
+            kind,
+            color_override=color,
+            text_fill_color=text_fill,
+            text_empty_color=text_empty,
         )
         ansi_str = "".join(sgr + text for sgr, text in fragments) + "\x1b[0m"
         try:
@@ -3526,16 +3647,17 @@ class ProgressBarEditPane(_EditListPane):
             c = bar_color_at(f, cfg)
             gradient_parts.append(f"[on {c}] [/]")
         try:
-            self.query_one("#pb-preview-gradient", Static).update(
-                "".join(gradient_parts)
-            )
+            self.query_one("#pb-preview-gradient", Static).update("".join(gradient_parts))
         except NoMatches:
             pass
 
     def _swap_color_options(
-        self, is_custom: bool,
-        preserve_max: str = "", preserve_min: str = "",
-        preserve_text_fill: str = "auto", preserve_text_empty: str = "auto",
+        self,
+        is_custom: bool,
+        preserve_max: str = "",
+        preserve_min: str = "",
+        preserve_text_fill: str = "auto",
+        preserve_text_empty: str = "auto",
     ) -> None:
         """Swap color dropdown options for theme vs custom mode."""
         options = self._color_options() if is_custom else self._theme_color_options()
@@ -3581,7 +3703,7 @@ class ProgressBarEditPane(_EditListPane):
             )
 
     def _populate_field_selects(
-        self, pkg_name: str, value_field: str = "", max_field: str = "",
+        self, pkg_name: str, value_field: str = "", max_field: str = ""
     ) -> None:
         """Populate value/max field Select widgets from GMCP snapshot fields."""
         fields = self._gmcp_fields.get(pkg_name, [])
@@ -3692,13 +3814,10 @@ _BOOKMARK_STYLE = "#ffffff"
 class ProgressBarEditScreen(_EditListScreen):
     """Thin screen wrapper for the progress bar editor."""
 
-    def __init__(
-        self, path: str, session_key: str = "", gmcp_snapshot_path: str = "",
-    ) -> None:
+    def __init__(self, path: str, session_key: str = "", gmcp_snapshot_path: str = "") -> None:
         super().__init__()
         self._pane = ProgressBarEditPane(
-            path=path, session_key=session_key,
-            gmcp_snapshot_path=gmcp_snapshot_path,
+            path=path, session_key=session_key, gmcp_snapshot_path=gmcp_snapshot_path
         )
 
 
@@ -3955,8 +4074,8 @@ class RoomBrowserPane(Vertical):
         """
         Select the tree node matching *room_num*.
 
-        Expands parent groups as needed and forces a tree rebuild
-        so that line numbers are valid before scrolling.
+        Expands parent groups as needed and forces a tree rebuild so that line numbers are valid
+        before scrolling.
 
         Return True on success.
         """
@@ -4105,8 +4224,9 @@ class RoomBrowserPane(Vertical):
             if area_filter and area != area_filter:
                 continue
             display_name = strip_exit_dirs(name)
-            if q and (q not in display_name.lower()
-                      and q not in area.lower() and q not in num.lower()):
+            if q and (
+                q not in display_name.lower() and q not in area.lower() and q not in num.lower()
+            ):
                 continue
             if display_name not in groups:
                 groups[display_name] = []
@@ -4298,8 +4418,7 @@ class RoomBrowserPane(Vertical):
             if event.key == "up" and idx > 0:
                 buttons[idx - 1].focus()
             elif event.key == "down":
-                (buttons[idx + 1] if idx < len(buttons) - 1
-                 else area_select).focus()
+                (buttons[idx + 1] if idx < len(buttons) - 1 else area_select).focus()
             elif event.key == "right":
                 search.focus()
             else:
@@ -4471,7 +4590,8 @@ class RoomBrowserScreen(Screen["bool | None"]):
     ) -> None:
         super().__init__()
         self._pane = RoomBrowserPane(
-            rooms_path=rooms_path, session_key=session_key,
+            rooms_path=rooms_path,
+            session_key=session_key,
             current_room_file=current_room_file,
             fasttravel_file=fasttravel_file,
         )
@@ -4535,16 +4655,10 @@ class _RoomPickerPane(RoomBrowserPane):
 class RoomPickerScreen(Screen["str | None"]):
     """Thin screen wrapper for the room picker."""
 
-    def __init__(
-        self,
-        rooms_path: str,
-        session_key: str = "",
-        current_room_file: str = "",
-    ) -> None:
+    def __init__(self, rooms_path: str, session_key: str = "", current_room_file: str = "") -> None:
         super().__init__()
         self._pane = _RoomPickerPane(
-            rooms_path=rooms_path, session_key=session_key,
-            current_room_file=current_room_file,
+            rooms_path=rooms_path, session_key=session_key, current_room_file=current_room_file
         )
 
     def compose(self) -> ComposeResult:
@@ -4562,7 +4676,8 @@ class _EditorApp(App[None]):
         self._session_key = session_key
 
     def _print_error_renderables(self) -> None:
-        """Print error tracebacks to stdout after alt screen exit.
+        """
+        Print error tracebacks to stdout after alt screen exit.
 
         Textual's default writes to ``error_console`` (stderr).  In the
         telix subprocess stderr may not translate ``\\n`` to ``\\r\\n``
@@ -4735,13 +4850,12 @@ def _run_editor_app(app: _EditorApp) -> None:
     """
     Run a Textual editor app, displaying errors in the terminal on crash.
 
-    Textual handles some exceptions internally (e.g. compose errors) --
-    it renders a traceback in the alt screen, then exits with return
-    code 1.  Once the alt screen is torn down the traceback is lost.
+    Textual handles some exceptions internally (e.g. compose errors) -- it renders a traceback in
+    the alt screen, then exits with return code 1.  Once the alt screen is torn down the traceback
+    is lost.
 
-    This wrapper catches both raised exceptions and Textual-handled
-    errors, resets the terminal to normal mode, displays the traceback,
-    and prompts the user before exiting.
+    This wrapper catches both raised exceptions and Textual-handled errors, resets the terminal to
+    normal mode, displays the traceback, and prompts the user before exiting.
     """
     try:
         app.run()
@@ -4783,9 +4897,7 @@ def _pause_before_exit() -> None:
         pass
 
 
-def _launch_editor(
-    screen: Screen[Any], session_key: str = "", logfile: str = ""
-) -> None:
+def _launch_editor(screen: Screen[Any], session_key: str = "", logfile: str = "") -> None:
     """Common bootstrap for standalone editor entry points."""
     _restore_blocking_fds(logfile)
     _log_child_diagnostics()
@@ -4804,10 +4916,13 @@ def edit_macros_main(
     """Launch standalone macro editor TUI."""
     _launch_editor(
         MacroEditScreen(
-            path=path, session_key=session_key,
-            rooms_file=rooms_file, current_room_file=current_room_file,
+            path=path,
+            session_key=session_key,
+            rooms_file=rooms_file,
+            current_room_file=current_room_file,
         ),
-        session_key=session_key, logfile=logfile,
+        session_key=session_key,
+        logfile=logfile,
     )
 
 
@@ -4817,7 +4932,8 @@ def edit_autoreplies_main(
     """Launch standalone autoreply editor TUI."""
     _launch_editor(
         AutoreplyEditScreen(path=path, session_key=session_key, select_pattern=select_pattern),
-        session_key=session_key, logfile=logfile,
+        session_key=session_key,
+        logfile=logfile,
     )
 
 
@@ -4825,7 +4941,8 @@ def edit_highlights_main(path: str, session_key: str = "", logfile: str = "") ->
     """Launch standalone highlight editor TUI."""
     _launch_editor(
         HighlightEditScreen(path=path, session_key=session_key),
-        session_key=session_key, logfile=logfile,
+        session_key=session_key,
+        logfile=logfile,
     )
 
 
@@ -4835,9 +4952,10 @@ def edit_progressbars_main(
     """Launch standalone progress bar editor TUI."""
     _launch_editor(
         ProgressBarEditScreen(
-            path=path, session_key=session_key, gmcp_snapshot_path=gmcp_snapshot_path,
+            path=path, session_key=session_key, gmcp_snapshot_path=gmcp_snapshot_path
         ),
-        session_key=session_key, logfile=logfile,
+        session_key=session_key,
+        logfile=logfile,
     )
 
 
@@ -4851,10 +4969,13 @@ def edit_rooms_main(
     """Launch standalone room browser TUI."""
     _launch_editor(
         RoomBrowserScreen(
-            rooms_path=rooms_path, session_key=session_key,
-            current_room_file=current_room_file, fasttravel_file=fasttravel_file,
+            rooms_path=rooms_path,
+            session_key=session_key,
+            current_room_file=current_room_file,
+            fasttravel_file=fasttravel_file,
         ),
-        session_key=session_key, logfile=logfile,
+        session_key=session_key,
+        logfile=logfile,
     )
 
 
@@ -5092,8 +5213,10 @@ class _CapsScreen(Screen[None]):
     ) -> None:
         super().__init__()
         self._pane = _CapsPane(
-            chat_file=chat_file, session_key=session_key,
-            initial_channel=initial_channel, capture_file=capture_file,
+            chat_file=chat_file,
+            session_key=session_key,
+            initial_channel=initial_channel,
+            capture_file=capture_file,
         )
 
     def compose(self) -> ComposeResult:
@@ -5186,7 +5309,8 @@ class _TabbedEditorScreen(Screen[None]):
     """
 
     def __init__(self, params: dict[str, Any]) -> None:
-        """Initialize tabbed editor from a parameters dict.
+        """
+        Initialize tabbed editor from a parameters dict.
 
         :param params: Dict with keys for each pane's constructor args, plus
             ``initial_tab`` and ``initial_channel``.
@@ -5217,32 +5341,53 @@ class _TabbedEditorScreen(Screen[None]):
 
     _PANE_FACTORIES: ClassVar[dict[str, tuple[type, dict[str, str]]]] = {
         "help": (_HelpPane, {"topic": ""}),
-        "highlights": (HighlightEditPane, {
-            "path": "highlights_file", "session_key": "session_key",
-        }),
-        "rooms": (RoomBrowserPane, {
-            "rooms_path": "rooms_file", "session_key": "session_key",
-            "current_room_file": "current_room_file",
-            "fasttravel_file": "fasttravel_file",
-        }),
-        "macros": (MacroEditPane, {
-            "path": "macros_file", "session_key": "session_key",
-            "rooms_file": "rooms_file",
-            "current_room_file": "current_room_file",
-        }),
-        "autoreplies": (AutoreplyEditPane, {
-            "path": "autoreplies_file", "session_key": "session_key",
-            "select_pattern": "select_pattern",
-        }),
-        "captures": (_CapsPane, {
-            "chat_file": "chat_file", "session_key": "session_key",
-            "initial_channel": "initial_channel",
-            "capture_file": "capture_file",
-        }),
-        "bars": (ProgressBarEditPane, {
-            "path": "progressbars_file", "session_key": "session_key",
-            "gmcp_snapshot_path": "gmcp_snapshot_file",
-        }),
+        "highlights": (
+            HighlightEditPane,
+            {"path": "highlights_file", "session_key": "session_key"},
+        ),
+        "rooms": (
+            RoomBrowserPane,
+            {
+                "rooms_path": "rooms_file",
+                "session_key": "session_key",
+                "current_room_file": "current_room_file",
+                "fasttravel_file": "fasttravel_file",
+            },
+        ),
+        "macros": (
+            MacroEditPane,
+            {
+                "path": "macros_file",
+                "session_key": "session_key",
+                "rooms_file": "rooms_file",
+                "current_room_file": "current_room_file",
+            },
+        ),
+        "autoreplies": (
+            AutoreplyEditPane,
+            {
+                "path": "autoreplies_file",
+                "session_key": "session_key",
+                "select_pattern": "select_pattern",
+            },
+        ),
+        "captures": (
+            _CapsPane,
+            {
+                "chat_file": "chat_file",
+                "session_key": "session_key",
+                "initial_channel": "initial_channel",
+                "capture_file": "capture_file",
+            },
+        ),
+        "bars": (
+            ProgressBarEditPane,
+            {
+                "path": "progressbars_file",
+                "session_key": "session_key",
+                "gmcp_snapshot_path": "gmcp_snapshot_file",
+            },
+        ),
     }
 
     def _create_pane(self, tab_id: str) -> Vertical:
@@ -5283,7 +5428,8 @@ class _TabbedEditorScreen(Screen[None]):
                     pane._refresh_table()
 
     def show_context_help(self, topic: str) -> None:
-        """Switch to the Help tab and display context-sensitive *topic*.
+        """
+        Switch to the Help tab and display context-sensitive *topic*.
 
         :param topic: Help topic key (e.g. ``"macro"``, ``"room"``).
         """
@@ -5296,7 +5442,7 @@ class _TabbedEditorScreen(Screen[None]):
         """Handle tab bar button clicks."""
         btn_id = event.button.id or ""
         if btn_id.startswith("te-btn-"):
-            tab_id = btn_id[len("te-btn-"):]
+            tab_id = btn_id[len("te-btn-") :]
             self.action_switch_tab(tab_id)
 
     def action_close_or_back(self) -> None:
@@ -5324,7 +5470,8 @@ class _TabbedEditorScreen(Screen[None]):
 
 
 def unified_editor_main() -> None:
-    """Launch the tabbed editor TUI subprocess.
+    """
+    Launch the tabbed editor TUI subprocess.
 
     Reads a single JSON blob from ``sys.argv[1]`` containing all parameters
     for every pane. Called from the REPL via ``_launch_unified_editor()``.
@@ -5565,17 +5712,13 @@ class _RandomwalkDialogScreen(Screen[bool]):
                     )
                     yield lbl
                     yield Input(
-                        value=str(self._default_visit_level),
-                        id="rw-visit-level", type="integer",
+                        value=str(self._default_visit_level), id="rw-visit-level", type="integer"
                     )
             with Vertical(id="rw-switches"):
                 with Horizontal(classes="rw-switch-row"):
                     with Horizontal(classes="rw-switch-cell"):
                         yield Label("Auto search:")
-                        yield Switch(
-                            value=self._default_auto_search,
-                            id="rw-auto-search",
-                        )
+                        yield Switch(value=self._default_auto_search, id="rw-auto-search")
                     with Horizontal(classes="rw-switch-cell"):
                         yield Label("Auto consider:")
                         yield Switch(
@@ -5593,10 +5736,7 @@ class _RandomwalkDialogScreen(Screen[bool]):
                         )
                     with Horizontal(classes="rw-switch-cell"):
                         yield Label("Autoreplies:")
-                        yield Switch(
-                            value=self._default_autoreplies,
-                            id="rw-autoreplies",
-                        )
+                        yield Switch(value=self._default_autoreplies, id="rw-autoreplies")
             yield Static("", id="rw-error")
             with Horizontal(id="rw-buttons"):
                 yield Button("Help", variant="primary", id="rw-help")
@@ -5631,9 +5771,7 @@ class _RandomwalkDialogScreen(Screen[bool]):
         auto_evaluate = self.query_one("#rw-auto-consider", Switch).value
         auto_survey = self.query_one("#rw-auto-survey", Switch).value
         autoreplies = self.query_one("#rw-autoreplies", Switch).value
-        self._write_result(
-            True, level, auto_search, auto_evaluate, auto_survey, autoreplies,
-        )
+        self._write_result(True, level, auto_search, auto_evaluate, auto_survey, autoreplies)
         self.dismiss(True)
 
     def on_button_pressed(self, event: Button.Pressed) -> None:
@@ -5846,10 +5984,7 @@ class _AutodiscoverDialogScreen(Screen[bool]):
                 with Horizontal(classes="ad-switch-row"):
                     with Horizontal(classes="ad-switch-cell"):
                         yield Label("Auto search:")
-                        yield Switch(
-                            value=self._default_auto_search,
-                            id="ad-auto-search",
-                        )
+                        yield Switch(value=self._default_auto_search, id="ad-auto-search")
                     with Horizontal(classes="ad-switch-cell"):
                         yield Label("Auto consider:")
                         yield Switch(
@@ -5867,10 +6002,7 @@ class _AutodiscoverDialogScreen(Screen[bool]):
                         )
                     with Horizontal(classes="ad-switch-cell"):
                         yield Label("Autoreplies:")
-                        yield Switch(
-                            value=self._default_autoreplies,
-                            id="ad-autoreplies",
-                        )
+                        yield Switch(value=self._default_autoreplies, id="ad-autoreplies")
             with Horizontal(id="ad-buttons"):
                 yield Button("Help", variant="primary", id="ad-help")
                 yield Button("Cancel", variant="error", id="ad-cancel")
@@ -5906,24 +6038,29 @@ class _AutodiscoverDialogScreen(Screen[bool]):
             auto_survey = self.query_one("#ad-auto-survey", Switch).value
             autoreplies = self.query_one("#ad-autoreplies", Switch).value
             self._write_result(
-                True, self._get_strategy(),
-                auto_search, auto_evaluate, auto_survey, autoreplies,
+                True, self._get_strategy(), auto_search, auto_evaluate, auto_survey, autoreplies
             )
             self.dismiss(True)
         elif event.button.id == "ad-cancel":
             self._write_result(
-                False, self._default_strategy,
-                self._default_auto_search, self._default_auto_evaluate,
-                self._default_auto_survey, self._default_autoreplies,
+                False,
+                self._default_strategy,
+                self._default_auto_search,
+                self._default_auto_evaluate,
+                self._default_auto_survey,
+                self._default_autoreplies,
             )
             self.dismiss(False)
 
     def action_cancel(self) -> None:
         """Cancel the dialog and write default values."""
         self._write_result(
-            False, self._default_strategy,
-            self._default_auto_search, self._default_auto_evaluate,
-            self._default_auto_survey, self._default_autoreplies,
+            False,
+            self._default_strategy,
+            self._default_auto_search,
+            self._default_auto_evaluate,
+            self._default_auto_survey,
+            self._default_autoreplies,
         )
         self.dismiss(False)
 
@@ -5949,15 +6086,17 @@ class _AutodiscoverDialogScreen(Screen[bool]):
         if not autoreplies:
             cmd += " noreply"
         cmd += "`"
-        result = json.dumps({
-            "confirmed": confirmed,
-            "strategy": strategy,
-            "auto_search": auto_search,
-            "auto_evaluate": auto_evaluate,
-            "auto_survey": auto_survey,
-            "autoreplies": autoreplies,
-            "command": cmd,
-        })
+        result = json.dumps(
+            {
+                "confirmed": confirmed,
+                "strategy": strategy,
+                "auto_search": auto_search,
+                "auto_evaluate": auto_evaluate,
+                "auto_survey": auto_survey,
+                "autoreplies": autoreplies,
+                "command": cmd,
+            }
+        )
         with open(self._result_file, "w", encoding="utf-8") as f:
             f.write(result)
 

--- a/telix/session_context.py
+++ b/telix/session_context.py
@@ -8,7 +8,10 @@ from typing import Any, Union, Callable, Optional, Awaitable
 
 # 3rd party
 from telnetlib3.stream_writer import TelnetWriter, TelnetWriterUnicode
-from telnetlib3._session_context import TelnetSessionContext  # pylint: disable=no-name-in-module
+from telnetlib3._session_context import TelnetSessionContext
+
+# local
+from .ws_transport import WebSocketWriter
 
 
 class _CommandQueue:
@@ -40,7 +43,7 @@ class SessionContext(TelnetSessionContext):
         super().__init__()
 
         # back-reference to the writer (set by _session_shell)
-        self.writer: Optional[Union[TelnetWriter, TelnetWriterUnicode]] = None
+        self.writer: Optional[Union[TelnetWriter, TelnetWriterUnicode, WebSocketWriter]] = None
 
         # identity
         self.session_key: str = session_key

--- a/telix/tests/test_client_shell.py
+++ b/telix/tests/test_client_shell.py
@@ -12,22 +12,32 @@ from unittest.mock import MagicMock
 import pytest
 
 # local
-from telix.client_shell import _want_repl, _load_configs, _build_session_key, telix_client_shell
+from telix.client_shell import (
+    _want_repl,
+    _load_configs,
+    ws_client_shell,
+    _build_session_key,
+    telix_client_shell,
+)
+from telix.ws_transport import WebSocketWriter
 from telix.session_context import SessionContext
 
 
 class TestBuildSessionKey:
-    def test_from_peername(self) -> None:
+    def test_from_peername(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.argv", ["telix"])
         writer = MagicMock()
         writer.get_extra_info.return_value = ("example.com", 4000)
         assert _build_session_key(writer) == "example.com:4000"
 
-    def test_no_peername(self) -> None:
+    def test_no_peername(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.argv", ["telix"])
         writer = MagicMock()
         writer.get_extra_info.return_value = None
         assert _build_session_key(writer) == ""
 
-    def test_ipv4(self) -> None:
+    def test_ipv4(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr("sys.argv", ["telix"])
         writer = MagicMock()
         writer.get_extra_info.return_value = ("192.168.1.1", 23)
         assert _build_session_key(writer) == "192.168.1.1:23"
@@ -163,6 +173,7 @@ class TestCtxPreservation:
     ) -> None:
         from telnetlib3._session_context import TelnetSessionContext
 
+        monkeypatch.setattr("sys.argv", ["telix"])
         monkeypatch.setattr("telix.client_shell._paths.CONFIG_DIR", str(tmp_path / "cfg"))
         monkeypatch.setattr("telix.client_shell._paths.DATA_DIR", str(tmp_path / "data"))
         monkeypatch.setattr("telix.client_shell._paths.xdg_config_dir", lambda: tmp_path / "cfg")
@@ -190,7 +201,7 @@ class TestCtxPreservation:
         writer.get_extra_info.return_value = ("example.com", 4000)
         writer.ctx = old_ctx
 
-        from telix.client_shell import _load_configs, _build_session_key
+        from telix.client_shell import _build_session_key
 
         session_key = _build_session_key(writer)
         _old_ctx = writer.ctx
@@ -220,3 +231,127 @@ class TestShellSignature:
 
         fn = function_lookup("telix.client_shell.telix_client_shell")
         assert fn is telix_client_shell
+
+
+class TestBuildSessionKeyWebSocket:
+    """_build_session_key uses peername directly for WebSocket writers."""
+
+    def test_ws_writer_uses_peername(self) -> None:
+        ws = MagicMock()
+        writer = WebSocketWriter(ws, peername=("gel.monster", 8443))
+        assert _build_session_key(writer) == "gel.monster:8443"
+
+    def test_ws_writer_no_peername(self) -> None:
+        ws = MagicMock()
+        writer = WebSocketWriter(ws, peername=None)
+        assert _build_session_key(writer) == ""
+
+    def test_ws_writer_skips_argv_parsing(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """WebSocket writers never try to parse telnetlib3 CLI args."""
+        monkeypatch.setattr(
+            "sys.argv",
+            ["telix", "--shell=telix.client_shell.telix_client_shell", "dunemud.net", "6788"],
+        )
+        ws = MagicMock()
+        writer = WebSocketWriter(ws, peername=("gel.monster", 8443))
+        # Should use peername, not argv host.
+        assert _build_session_key(writer) == "gel.monster:8443"
+
+
+class TestWsClientShellSignature:
+    """ws_client_shell is a coroutine and resolvable by function_lookup."""
+
+    def test_is_coroutine_function(self) -> None:
+        assert asyncio.iscoroutinefunction(ws_client_shell)
+
+    def test_resolvable_via_function_lookup(self) -> None:
+        from telnetlib3.accessories import function_lookup
+
+        fn = function_lookup("telix.client_shell.ws_client_shell")
+        assert fn is ws_client_shell
+
+
+class TestWsClientShellGMCP:
+    """ws_client_shell wires GMCP dispatch callbacks correctly."""
+
+    def _make_writer(self) -> WebSocketWriter:
+        ws = MagicMock()
+        return WebSocketWriter(ws, peername=("gel.monster", 8443))
+
+    def test_gmcp_callback_registered(self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        """ws_client_shell registers a GMCP ext callback on the writer."""
+        monkeypatch.setattr("telix.client_shell._paths.xdg_config_dir", lambda: tmp_path / "cfg")
+        monkeypatch.setattr("telix.client_shell._paths.xdg_data_dir", lambda: tmp_path / "data")
+        monkeypatch.setattr(
+            "telix.client_shell._paths.chat_path",
+            lambda sk: str(tmp_path / "data" / f"chat-{sk}.json"),
+        )
+        monkeypatch.setattr(
+            "telix.client_shell._paths.history_path",
+            lambda sk: str(tmp_path / "data" / f"history-{sk}"),
+        )
+        monkeypatch.setattr(
+            "telix.rooms.rooms_path", lambda sk: str(tmp_path / "data" / f"rooms-{sk}.db")
+        )
+
+        from telix.ws_transport import _GMCP
+
+        writer = self._make_writer()
+
+        # We cannot run the full ws_client_shell (it needs a TTY and blessed),
+        # so test the setup steps directly.
+        session_key = _build_session_key(writer)
+        ctx = SessionContext(session_key=session_key)
+        ctx.writer = writer
+        ctx.repl_enabled = True
+        writer.ctx = ctx
+        _load_configs(ctx)
+
+        # Simulate the GMCP callback setup from ws_client_shell.
+        def _on_gmcp(package: str, data: Any) -> None:
+            if package == "Room.Info":
+                if ctx.on_room_info is not None:
+                    ctx.on_room_info(data)
+
+        writer.set_ext_callback(_GMCP, _on_gmcp)
+        assert _GMCP in writer._ext_callback
+
+    def test_room_info_dispatch(self, tmp_path: Any, monkeypatch: pytest.MonkeyPatch) -> None:
+        """GMCP Room.Info dispatches to ctx.on_room_info."""
+        monkeypatch.setattr("telix.client_shell._paths.xdg_config_dir", lambda: tmp_path / "cfg")
+        monkeypatch.setattr("telix.client_shell._paths.xdg_data_dir", lambda: tmp_path / "data")
+        monkeypatch.setattr(
+            "telix.client_shell._paths.chat_path",
+            lambda sk: str(tmp_path / "data" / f"chat-{sk}.json"),
+        )
+        monkeypatch.setattr(
+            "telix.client_shell._paths.history_path",
+            lambda sk: str(tmp_path / "data" / f"history-{sk}"),
+        )
+        monkeypatch.setattr(
+            "telix.rooms.rooms_path", lambda sk: str(tmp_path / "data" / f"rooms-{sk}.db")
+        )
+
+        from telix.ws_transport import _GMCP
+
+        writer = self._make_writer()
+        session_key = _build_session_key(writer)
+        ctx = SessionContext(session_key=session_key)
+        ctx.writer = writer
+        writer.ctx = ctx
+        _load_configs(ctx)
+
+        received: list[Any] = []
+        ctx.on_room_info = received.append
+
+        def _on_gmcp(package: str, data: Any) -> None:
+            if package == "Room.Info":
+                if ctx.on_room_info is not None:
+                    ctx.on_room_info(data)
+
+        writer.set_ext_callback(_GMCP, _on_gmcp)
+
+        # Dispatch via the writer's GMCP mechanism.
+        room_data = {"num": "42", "name": "Test Room"}
+        writer.dispatch_gmcp("Room.Info", room_data)
+        assert received == [room_data]

--- a/telix/tests/test_client_tui.py
+++ b/telix/tests/test_client_tui.py
@@ -15,7 +15,9 @@ pytest.importorskip("textual", reason="textual not installed")
 
 # local
 from telix.client_tui import (  # noqa: E402
+    _EDITOR_TABS,
     DEFAULTS_KEY,
+    _PRIMARY_PASTE_COMMANDS,
     SessionConfig,
     MacroEditScreen,
     TelnetSessionApp,
@@ -32,12 +34,10 @@ from telix.client_tui import (  # noqa: E402
     _build_tooltips,
     _get_help_topic,
     _CommandHelpScreen,
-    _RandomwalkDialogScreen,
-    _AutodiscoverDialogScreen,
     _TabbedEditorScreen,
-    _EDITOR_TABS,
+    _RandomwalkDialogScreen,
     _read_primary_selection,
-    _PRIMARY_PASTE_COMMANDS,
+    _AutodiscoverDialogScreen,
 )
 
 
@@ -235,6 +235,66 @@ def test_build_command_missing_host() -> None:
     cfg = SessionConfig(host="", port=23)
     cmd = build_command(cfg)
     assert "" in cmd
+
+
+def test_build_command_websocket_with_ssl() -> None:
+    """WebSocket protocol with SSL builds telix-ws command with wss:// URL."""
+    cfg = SessionConfig(protocol="websocket", host="gel.monster", port=443, ssl=True, ws_path="/ws")
+    cmd = build_command(cfg)
+    assert cmd[0] == sys.executable
+    assert "from telix.ws_client import main; main()" in cmd
+    assert "wss://gel.monster/ws" in cmd
+    assert "telnetlib3" not in " ".join(cmd)
+
+
+def test_build_command_websocket_without_ssl() -> None:
+    """WebSocket protocol without SSL builds URL from host:port."""
+    cfg = SessionConfig(protocol="websocket", host="gel.monster", port=8443)
+    cmd = build_command(cfg)
+    assert "ws://gel.monster:8443" in cmd
+
+
+def test_build_command_websocket_standard_port_omitted() -> None:
+    """Standard ports (443 for wss, 80 for ws) are omitted from the URL."""
+    cfg_wss = SessionConfig(protocol="websocket", host="mud.example", port=443, ssl=True)
+    assert "wss://mud.example" in build_command(cfg_wss)
+    assert ":443" not in " ".join(build_command(cfg_wss))
+
+    cfg_ws = SessionConfig(protocol="websocket", host="mud.example", port=80, ssl=False)
+    assert "ws://mud.example" in build_command(cfg_ws)
+    assert ":80" not in " ".join(build_command(cfg_ws))
+
+
+def test_build_command_websocket_ws_path() -> None:
+    """ws_path is appended to the WebSocket URL."""
+    cfg = SessionConfig(
+        protocol="websocket", host="mud.example", port=4002, ssl=False, ws_path="/game"
+    )
+    cmd = build_command(cfg)
+    assert "ws://mud.example:4002/game" in cmd
+
+
+def test_build_command_websocket_ws_path_no_leading_slash() -> None:
+    """ws_path without leading slash gets one prepended."""
+    cfg = SessionConfig(
+        protocol="websocket", host="mud.example", port=4002, ssl=False, ws_path="ws"
+    )
+    cmd = build_command(cfg)
+    assert "ws://mud.example:4002/ws" in cmd
+
+
+def test_build_command_websocket_ws_path_empty() -> None:
+    """Empty ws_path produces no trailing path."""
+    cfg = SessionConfig(protocol="websocket", host="mud.example", port=4002, ssl=False, ws_path="")
+    cmd = build_command(cfg)
+    assert "ws://mud.example:4002" in cmd
+
+
+def test_build_command_telnet_default_protocol() -> None:
+    """Default protocol is telnet."""
+    cfg = SessionConfig(host="example.com", port=23)
+    cmd = build_command(cfg)
+    assert "telnetlib3" in cmd[2]
 
 
 def test_macro_screen_loads_empty(tmp_path) -> None:
@@ -570,8 +630,7 @@ def test_autodiscover_dialog_all_flags(tmp_path: Any) -> None:
     result_file = str(tmp_path / "result.json")
     screen = _AutodiscoverDialogScreen(result_file=result_file, default_strategy="bfs")
     screen._write_result(
-        True, "bfs",
-        auto_search=True, auto_evaluate=True, auto_survey=True, autoreplies=True,
+        True, "bfs", auto_search=True, auto_evaluate=True, auto_survey=True, autoreplies=True
     )
 
     with open(result_file, "r", encoding="utf-8") as f:
@@ -653,8 +712,7 @@ def test_randomwalk_dialog_all_new_flags(tmp_path: Any) -> None:
     result_file = str(tmp_path / "result.json")
     screen = _RandomwalkDialogScreen(result_file=result_file, default_visit_level=3)
     screen._write_result(
-        True, 3,
-        auto_search=True, auto_evaluate=True, auto_survey=True, autoreplies=True,
+        True, 3, auto_search=True, auto_evaluate=True, auto_survey=True, autoreplies=True
     )
 
     with open(result_file, "r", encoding="utf-8") as f:
@@ -675,9 +733,7 @@ def test_randomwalk_dialog_noreply_with_flags(tmp_path: Any) -> None:
 
 
 def test_randomwalk_dialog_default_autoreplies() -> None:
-    screen = _RandomwalkDialogScreen(
-        default_auto_survey=True, default_autoreplies=False,
-    )
+    screen = _RandomwalkDialogScreen(default_auto_survey=True, default_autoreplies=False)
     assert screen._default_auto_survey is True
     assert screen._default_autoreplies is False
 
@@ -734,10 +790,7 @@ class TestTabbedEditorScreen:
 
     def test_editor_tabs_ids(self) -> None:
         ids = [tab_id for _, tab_id in _EDITOR_TABS]
-        assert ids == [
-            "help", "highlights", "rooms", "macros",
-            "autoreplies", "captures", "bars",
-        ]
+        assert ids == ["help", "highlights", "rooms", "macros", "autoreplies", "captures", "bars"]
 
     def test_create_pane_help(self, tmp_path: Any) -> None:
         from telix.client_tui import _HelpPane
@@ -805,7 +858,7 @@ class TestTabbedEditorScreen:
 
 class TestReadPrimarySelection:
     def test_returns_text_from_first_available_helper(self, monkeypatch: Any) -> None:
-        from unittest.mock import patch, MagicMock
+        from unittest.mock import MagicMock, patch
 
         fake_result = MagicMock()
         fake_result.returncode = 0
@@ -814,12 +867,11 @@ class TestReadPrimarySelection:
             result = _read_primary_selection()
         assert result == "hello world"
         m.assert_called_once_with(
-            _PRIMARY_PASTE_COMMANDS[0],
-            capture_output=True, timeout=2, check=False,
+            _PRIMARY_PASTE_COMMANDS[0], capture_output=True, timeout=2, check=False
         )
 
     def test_tries_next_command_on_file_not_found(self, monkeypatch: Any) -> None:
-        from unittest.mock import patch, MagicMock
+        from unittest.mock import MagicMock, patch
 
         fake_result = MagicMock()
         fake_result.returncode = 0
@@ -841,13 +893,11 @@ class TestReadPrimarySelection:
     def test_returns_empty_when_no_helpers_available(self) -> None:
         from unittest.mock import patch
 
-        with patch(
-            "telix.client_tui.subprocess.run", side_effect=FileNotFoundError,
-        ):
+        with patch("telix.client_tui.subprocess.run", side_effect=FileNotFoundError):
             assert _read_primary_selection() == ""
 
     def test_skips_helper_with_nonzero_exit(self) -> None:
-        from unittest.mock import patch, MagicMock
+        from unittest.mock import MagicMock, patch
 
         fail = MagicMock(returncode=1, stdout=b"")
         ok = MagicMock(returncode=0, stdout=b"ok")

--- a/telix/tests/test_ws_transport.py
+++ b/telix/tests/test_ws_transport.py
@@ -1,0 +1,350 @@
+"""Tests for telix.ws_transport -- WebSocket reader/writer adapters."""
+
+from __future__ import annotations
+
+# std imports
+import json
+import asyncio
+from typing import Any
+from unittest.mock import MagicMock
+
+# 3rd party
+import pytest
+
+# local
+from telix.ws_transport import WebSocketReader, WebSocketWriter
+
+
+class TestWebSocketReader:
+    """WebSocketReader provides an async read() interface fed by feed_data/feed_eof."""
+
+    @pytest.mark.asyncio
+    async def test_read_returns_fed_data(self) -> None:
+        """Read() returns data previously fed via feed_data."""
+        reader = WebSocketReader()
+        reader.feed_data(b"hello")
+        result = await reader.read(1024)
+        assert result == "hello"
+
+    @pytest.mark.asyncio
+    async def test_read_blocks_until_data(self) -> None:
+        """Read() blocks until feed_data is called."""
+        reader = WebSocketReader()
+        loop = asyncio.get_event_loop()
+        loop.call_later(0.01, reader.feed_data, b"delayed")
+        result = await asyncio.wait_for(reader.read(1024), timeout=1.0)
+        assert result == "delayed"
+
+    @pytest.mark.asyncio
+    async def test_read_returns_empty_at_eof(self) -> None:
+        """Read() returns empty string after feed_eof."""
+        reader = WebSocketReader()
+        reader.feed_eof()
+        result = await reader.read(1024)
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_at_eof(self) -> None:
+        """at_eof() reflects EOF state."""
+        reader = WebSocketReader()
+        assert reader.at_eof() is False
+        reader.feed_eof()
+        assert reader.at_eof() is True
+
+    @pytest.mark.asyncio
+    async def test_multiple_feeds_concatenate(self) -> None:
+        """Multiple feed_data calls are returned in order."""
+        reader = WebSocketReader()
+        reader.feed_data(b"aaa")
+        reader.feed_data(b"bbb")
+        result = await reader.read(1024)
+        assert result == "aaa"
+        result = await reader.read(1024)
+        assert result == "bbb"
+
+    @pytest.mark.asyncio
+    async def test_feed_data_decodes_utf8(self) -> None:
+        """Binary data is decoded as UTF-8."""
+        reader = WebSocketReader()
+        reader.feed_data(b"hello \xc3\xa9")
+        result = await reader.read(1024)
+        assert result == "hello \xe9"
+
+    @pytest.mark.asyncio
+    async def test_wakeup_waiter_unblocks_read(self) -> None:
+        """_wakeup_waiter() feeds an empty string to unblock a pending read()."""
+        reader = WebSocketReader()
+        loop = asyncio.get_event_loop()
+        loop.call_later(0.01, reader._wakeup_waiter)
+        result = await asyncio.wait_for(reader.read(1024), timeout=1.0)
+        assert result == ""
+
+    @pytest.mark.asyncio
+    async def test_wakeup_waiter_does_not_set_eof(self) -> None:
+        """_wakeup_waiter() unblocks read but does not signal EOF."""
+        reader = WebSocketReader()
+        reader._wakeup_waiter()
+        await reader.read(1024)
+        assert reader.at_eof() is False
+
+
+class TestWebSocketWriter:
+    """WebSocketWriter wraps a websockets connection for sending."""
+
+    def _make_writer(self, **overrides: Any) -> WebSocketWriter:
+        ws = MagicMock()
+        ws.send = MagicMock()
+        return WebSocketWriter(ws, **overrides)
+
+    def test_write_queues_binary_frame(self) -> None:
+        """Write() enqueues text encoded as bytes for the drain task."""
+        writer = self._make_writer()
+        writer.write("hello\r\n")
+        item = writer._send_queue.get_nowait()
+        assert item == b"hello\r\n"
+
+    def test_write_passes_bytes_through(self) -> None:
+        """Write() with bytes input passes them through without re-encoding."""
+        writer = self._make_writer()
+        raw = b"\xff\xfe\x01\x02"
+        writer.write(raw)
+        item = writer._send_queue.get_nowait()
+        assert item is raw
+
+    def test_will_echo_default_false(self) -> None:
+        """will_echo defaults to False (server not echoing)."""
+        writer = self._make_writer()
+        assert writer.will_echo is False
+
+    def test_mode_default_local(self) -> None:
+        """Mode defaults to 'local' for REPL compatibility."""
+        writer = self._make_writer()
+        assert writer.mode == "local"
+
+    def test_get_extra_info_peername(self) -> None:
+        """get_extra_info returns configured peername."""
+        writer = self._make_writer(peername=("gel.monster", 8443))
+        assert writer.get_extra_info("peername") == ("gel.monster", 8443)
+
+    def test_get_extra_info_default(self) -> None:
+        """get_extra_info returns default for unknown keys."""
+        writer = self._make_writer()
+        assert writer.get_extra_info("unknown", "fallback") == "fallback"
+
+    def test_get_extra_info_ssl_object_returns_none(self) -> None:
+        """get_extra_info('ssl_object') always returns None (no TLS on inner WS)."""
+        writer = self._make_writer()
+        assert writer.get_extra_info("ssl_object") is None
+
+    def test_get_extra_info_peername_default_when_unset(self) -> None:
+        """get_extra_info('peername') returns default when peername not configured."""
+        writer = self._make_writer()
+        assert writer.get_extra_info("peername", "fallback") == "fallback"
+
+    def test_close_signals_drain_to_stop(self) -> None:
+        """Close() places a None sentinel on the send queue."""
+        writer = self._make_writer()
+        writer.close()
+        assert writer.is_closing() is True
+        item = writer._send_queue.get_nowait()
+        assert item is None
+
+    def test_set_ext_callback(self) -> None:
+        """set_ext_callback stores callback by key."""
+        writer = self._make_writer()
+        cb = MagicMock()
+        writer.set_ext_callback(b"\xc9", cb)
+        assert writer._ext_callback[b"\xc9"] is cb
+
+    def test_set_iac_callback(self) -> None:
+        """set_iac_callback stores callback by key."""
+        writer = self._make_writer()
+        cb = MagicMock()
+        writer.set_iac_callback(b"\xf9", cb)
+        assert writer._iac_callback[b"\xf9"] is cb
+
+    def test_log_attribute(self) -> None:
+        """Writer exposes a log attribute."""
+        writer = self._make_writer()
+        assert writer.log is not None
+
+    def test_local_option_enabled_returns_false(self) -> None:
+        """local_option.enabled() returns False for any telnet option."""
+        writer = self._make_writer()
+        assert writer.local_option.enabled(b"\x18") is False
+        assert writer.local_option.enabled(b"\x01") is False
+
+    def test_remote_option_enabled_returns_false(self) -> None:
+        """remote_option.enabled() returns False for any telnet option."""
+        writer = self._make_writer()
+        assert writer.remote_option.enabled(b"\x18") is False
+        assert writer.remote_option.enabled(b"\x01") is False
+
+
+class TestGMCPDispatch:
+    """GMCP TEXT frames are dispatched to ext callbacks."""
+
+    def test_gmcp_text_frame_dispatched(self) -> None:
+        """A TEXT frame triggers the GMCP ext callback."""
+        ws = MagicMock()
+        writer = WebSocketWriter(ws)
+        received: list[tuple[str, Any]] = []
+        writer.set_ext_callback(b"\xc9", lambda pkg, data: received.append((pkg, data)))
+        writer.dispatch_gmcp("Room.Info", {"num": "1", "name": "Town"})
+        assert len(received) == 1
+        assert received[0] == ("Room.Info", {"num": "1", "name": "Town"})
+
+    def test_gmcp_no_callback_no_error(self) -> None:
+        """dispatch_gmcp with no registered callback does not raise."""
+        ws = MagicMock()
+        writer = WebSocketWriter(ws)
+        writer.dispatch_gmcp("Room.Info", {"num": "1"})
+
+    def test_gmcp_string_payload(self) -> None:
+        """dispatch_gmcp handles string-only GMCP payload."""
+        ws = MagicMock()
+        writer = WebSocketWriter(ws)
+        received: list[tuple[str, Any]] = []
+        writer.set_ext_callback(b"\xc9", lambda pkg, data: received.append((pkg, data)))
+        writer.dispatch_gmcp("Core.Goodbye", None)
+        assert received[0] == ("Core.Goodbye", None)
+
+
+class TestPseudoPromptSignal:
+    """WebSocket message boundaries fire GA/EOR callbacks as pseudo-prompt."""
+
+    def test_prompt_signal_fires_ga_callback(self) -> None:
+        """fire_prompt_signal invokes the GA IAC callback."""
+        ws = MagicMock()
+        writer = WebSocketWriter(ws)
+        calls: list[bytes] = []
+        writer.set_iac_callback(b"\xf9", calls.append)
+        writer.fire_prompt_signal()
+        assert calls == [b"\xf9"]
+
+    def test_prompt_signal_fires_eor_callback(self) -> None:
+        """fire_prompt_signal invokes the EOR IAC callback."""
+        ws = MagicMock()
+        writer = WebSocketWriter(ws)
+        calls: list[bytes] = []
+        writer.set_iac_callback(b"\xef", calls.append)
+        writer.fire_prompt_signal()
+        assert calls == [b"\xef"]
+
+    def test_prompt_signal_no_callbacks_no_error(self) -> None:
+        """fire_prompt_signal with no registered callbacks does not raise."""
+        ws = MagicMock()
+        writer = WebSocketWriter(ws)
+        writer.fire_prompt_signal()
+
+
+class TestParseGMCPFrame:
+    """parse_gmcp_frame extracts package name and JSON payload from TEXT frames."""
+
+    def test_package_with_json_object(self) -> None:
+        """Standard GMCP: 'Package.Name {...}'."""
+        from telix.ws_transport import parse_gmcp_frame
+
+        pkg, data = parse_gmcp_frame('Room.Info {"num":"1","name":"Town"}')
+        assert pkg == "Room.Info"
+        assert data == {"num": "1", "name": "Town"}
+
+    def test_package_with_json_array(self) -> None:
+        """GMCP with array payload."""
+        from telix.ws_transport import parse_gmcp_frame
+
+        pkg, data = parse_gmcp_frame('Comm.Channel.List [{"name":"chat"}]')
+        assert pkg == "Comm.Channel.List"
+        assert data == [{"name": "chat"}]
+
+    def test_package_no_payload(self) -> None:
+        """GMCP with no JSON payload returns None."""
+        from telix.ws_transport import parse_gmcp_frame
+
+        pkg, data = parse_gmcp_frame("Core.Goodbye")
+        assert pkg == "Core.Goodbye"
+        assert data is None
+
+    def test_package_with_string_payload(self) -> None:
+        """GMCP with a JSON string payload."""
+        from telix.ws_transport import parse_gmcp_frame
+
+        pkg, data = parse_gmcp_frame('Core.Hello "telnetlib3"')
+        assert pkg == "Core.Hello"
+        assert data == "telnetlib3"
+
+    def test_package_with_numeric_payload(self) -> None:
+        """GMCP with a numeric payload."""
+        from telix.ws_transport import parse_gmcp_frame
+
+        pkg, data = parse_gmcp_frame("Char.Level 42")
+        assert pkg == "Char.Level"
+        assert data == 42
+
+    def test_empty_string_raises(self) -> None:
+        """Empty string raises ValueError."""
+        from telix.ws_transport import parse_gmcp_frame
+
+        with pytest.raises(ValueError):
+            parse_gmcp_frame("")
+
+    def test_malformed_json_returns_raw_string(self) -> None:
+        """Malformed JSON payload is returned as raw string."""
+        from telix.ws_transport import parse_gmcp_frame
+
+        pkg, data = parse_gmcp_frame("Foo.Bar {bad json}")
+        assert pkg == "Foo.Bar"
+        assert data == "{bad json}"
+
+
+class TestSendGMCP:
+    """WebSocketWriter.send_gmcp enqueues TEXT frames in GMCP format."""
+
+    def test_send_gmcp_with_dict(self) -> None:
+        """send_gmcp enqueues 'Package.Name json' for the drain task."""
+        ws = MagicMock()
+        writer = WebSocketWriter(ws)
+        writer.send_gmcp("Core.Supports.Set", ["Room 1", "Char 1"])
+        sent = writer._send_queue.get_nowait()
+        assert isinstance(sent, str)
+        assert sent.startswith("Core.Supports.Set ")
+        assert json.loads(sent.split(" ", 1)[1]) == ["Room 1", "Char 1"]
+
+    def test_send_gmcp_no_payload(self) -> None:
+        """send_gmcp with None payload enqueues package name only."""
+        ws = MagicMock()
+        writer = WebSocketWriter(ws)
+        writer.send_gmcp("Core.Goodbye", None)
+        sent = writer._send_queue.get_nowait()
+        assert sent == "Core.Goodbye"
+
+
+class TestDrain:
+    """WebSocketWriter.drain() sends queued items over the WebSocket."""
+
+    @pytest.mark.asyncio
+    async def test_drain_sends_queued_items(self) -> None:
+        """Drain() awaits ws.send() for each queued item in order."""
+        ws = MagicMock()
+        sent: list[Any] = []
+
+        async def fake_send(item: Any) -> None:
+            sent.append(item)
+
+        ws.send = fake_send
+        writer = WebSocketWriter(ws)
+        writer.write("hello")
+        writer.send_gmcp("Core.Ping")
+        writer.close()  # places None sentinel
+        await writer.drain()
+        assert sent == [b"hello", "Core.Ping"]
+
+    @pytest.mark.asyncio
+    async def test_drain_stops_on_close(self) -> None:
+        """Drain() exits when close() places a None sentinel."""
+        ws = MagicMock()
+        ws.send = MagicMock(side_effect=lambda _: asyncio.sleep(0))
+        writer = WebSocketWriter(ws)
+        writer.close()
+        # drain should return promptly (None sentinel is already queued).
+        await asyncio.wait_for(writer.drain(), timeout=1.0)

--- a/telix/ws_client.py
+++ b/telix/ws_client.py
@@ -1,0 +1,126 @@
+"""
+WebSocket client entry point for telix.
+
+Provides :func:`main`, the ``telix-ws`` console script entry point, and
+:func:`run_ws_client`, which connects to a WebSocket MUD server using
+the ``gmcp.mudstandards.org`` subprotocol, creates reader/writer
+adapters, runs the receive loop, and invokes the telix shell.
+
+This module mirrors the role of ``telnetlib3.client`` but for WebSocket
+connections.  The TUI launches it as a subprocess (the same way it
+launches ``telnetlib3-client`` for telnet sessions).
+"""
+
+from __future__ import annotations
+
+# std imports
+import sys
+import asyncio
+import logging
+import argparse
+from typing import Optional
+from urllib.parse import urlparse
+
+# local
+from .ws_transport import WebSocketReader, WebSocketWriter, parse_gmcp_frame
+
+log = logging.getLogger(__name__)
+
+_WS_SUBPROTOCOL = "gmcp.mudstandards.org"
+
+
+async def run_ws_client(url: str, shell: str = "telix.client_shell.ws_client_shell") -> None:
+    """
+    Connect to a WebSocket MUD server and run the telix shell.
+
+    :param url: WebSocket URL (e.g. ``wss://gel.monster:8443``).
+    :param shell: Dotted path to the shell coroutine.
+    """
+    import websockets
+    import websockets.exceptions
+    from websockets.typing import Subprotocol
+
+    parsed = urlparse(url)
+    host = parsed.hostname or "localhost"
+    port = parsed.port or (443 if parsed.scheme == "wss" else 80)
+
+    reader = WebSocketReader()
+    writer: Optional[WebSocketWriter] = None
+
+    # Resolve the shell function.
+    from telnetlib3.accessories import function_lookup
+
+    shell_fn = function_lookup(shell)
+
+    async with websockets.connect(
+        url, subprotocols=[Subprotocol(_WS_SUBPROTOCOL)], max_size=2**20, open_timeout=10
+    ) as ws:
+        writer = WebSocketWriter(ws, peername=(host, port))
+
+        # Create a minimal session context for the writer.
+        from telnetlib3._session_context import TelnetSessionContext
+
+        writer.ctx = TelnetSessionContext()
+
+        async def _receive_loop() -> None:
+            """Read WebSocket frames and dispatch to reader/writer."""
+            assert writer is not None
+            try:
+                async for message in ws:
+                    if isinstance(message, bytes):
+                        # BINARY frame = raw game text.
+                        reader.feed_data(message)
+                        writer.fire_prompt_signal()
+                    elif isinstance(message, str):
+                        # TEXT frame = GMCP message.
+                        try:
+                            pkg, data = parse_gmcp_frame(message)
+                            writer.dispatch_gmcp(pkg, data)
+                        except ValueError:
+                            log.warning("invalid GMCP frame: %r", message[:80])
+            except websockets.exceptions.ConnectionClosed:
+                log.debug("WebSocket connection closed")
+            finally:
+                reader.feed_eof()
+
+        recv_task = asyncio.ensure_future(_receive_loop())
+        drain_task = asyncio.ensure_future(writer.drain())
+
+        try:
+            await shell_fn(reader, writer)
+        finally:
+            writer.close()
+            recv_task.cancel()
+            for task in (recv_task, drain_task):
+                try:
+                    await task
+                except asyncio.CancelledError:
+                    pass
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    """Build the argument parser for ``telix-ws``."""
+    parser = argparse.ArgumentParser(
+        prog="telix-ws", description="Connect to a WebSocket MUD server."
+    )
+    parser.add_argument("url", help="WebSocket URL (e.g. wss://gel.monster:8443)")
+    parser.add_argument(
+        "--shell",
+        default="telix.client_shell.ws_client_shell",
+        help="Dotted path to shell coroutine (default: telix WS shell).",
+    )
+    return parser
+
+
+def main() -> None:
+    """Entry point for the ``telix-ws`` console script."""
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    try:
+        asyncio.run(run_ws_client(url=args.url, shell=args.shell))
+    except KeyboardInterrupt:
+        pass
+    except OSError as err:
+        print(f"Error: {err}", file=sys.stderr)
+        sys.exit(1)

--- a/telix/ws_transport.py
+++ b/telix/ws_transport.py
@@ -1,0 +1,267 @@
+"""
+WebSocket reader/writer adapters for MUD client sessions.
+
+Provides :class:`WebSocketReader` and :class:`WebSocketWriter`, which
+present a compatible interface to telnetlib3's
+:class:`~telnetlib3.stream_reader.TelnetReader` and
+:class:`~telnetlib3.stream_writer.TelnetWriter` so that the REPL and
+shell can operate over a WebSocket transport without modification.
+
+The ``gmcp.mudstandards.org`` wire format is used:
+
+- **BINARY frames** carry raw ANSI/UTF-8 game text.
+- **TEXT frames** carry GMCP messages in ``"Package.Name json"`` format.
+
+Each delivered BINARY frame fires the stored GA/EOR IAC callback as a
+pseudo-prompt signal, giving the REPL the same prompt boundary that
+telnet provides via IAC GA / IAC EOR.
+"""
+
+from __future__ import annotations
+
+# std imports
+import json
+import asyncio
+import logging
+from typing import Any, Dict, Tuple, Union, Optional
+
+log = logging.getLogger(__name__)
+
+# IAC command bytes used as callback keys (matching telnetlib3 conventions).
+_GA = b"\xf9"
+_CMD_EOR = b"\xef"
+# GMCP telopt byte used as ext callback key.
+_GMCP = b"\xc9"
+
+__all__ = ("WebSocketReader", "WebSocketWriter", "parse_gmcp_frame")
+
+
+def parse_gmcp_frame(text: str) -> Tuple[str, Any]:
+    """
+    Parse a GMCP TEXT frame into ``(package_name, payload)``.
+
+    The format is ``"Package.Name optional_json_payload"``.  If no payload
+    is present, *payload* is ``None``.  Malformed JSON is returned as a
+    raw string.
+
+    :param text: Raw TEXT frame content.
+    :returns: ``(package_name, parsed_payload)``
+    :raises ValueError: If *text* is empty.
+    """
+    if not text:
+        raise ValueError("empty GMCP frame")
+    parts = text.split(" ", 1)
+    package = parts[0]
+    if len(parts) == 1:
+        return (package, None)
+    raw = parts[1]
+    try:
+        return (package, json.loads(raw))
+    except (json.JSONDecodeError, ValueError):
+        return (package, raw)
+
+
+class WebSocketReader:
+    """
+    Async reader fed by WebSocket BINARY frames.
+
+    Presents the same ``read()`` / ``at_eof()`` interface as
+    :class:`~telnetlib3.stream_reader.TelnetReader` so the REPL's
+    ``_read_server`` loop works without changes.
+    """
+
+    def __init__(self) -> None:
+        """Initialise the reader with an empty queue."""
+        self._buffer: asyncio.Queue[Optional[str]] = asyncio.Queue()
+        self._eof = False
+
+    def feed_data(self, data: bytes) -> None:
+        """
+        Enqueue decoded text from a BINARY WebSocket frame.
+
+        :param data: Raw bytes (UTF-8 encoded game text).
+        """
+        self._buffer.put_nowait(data.decode("utf-8", errors="replace"))
+
+    def feed_eof(self) -> None:
+        """Signal end-of-stream."""
+        self._eof = True
+        self._buffer.put_nowait(None)
+
+    def at_eof(self) -> bool:
+        """Return ``True`` if EOF has been signalled."""
+        return self._eof
+
+    async def read(self, n: int = -1) -> str:
+        """
+        Read the next chunk of server text.
+
+        Blocks until data is available.  Returns an empty string at EOF.
+
+        :param n: Ignored (present for API compatibility).
+        """
+        if self._eof and self._buffer.empty():
+            return ""
+        chunk = await self._buffer.get()
+        if chunk is None:
+            return ""
+        return chunk
+
+    # telnetlib3 TelnetReader compatibility -- the REPL calls this
+    # to wake the reader when a prompt signal arrives mid-read.
+    def _wakeup_waiter(self) -> None:
+        """Wake any blocked ``read()`` call (feed empty string to unblock)."""
+        self._buffer.put_nowait("")
+
+
+class _NullOptionSet:
+    """Stub for ``telnet_writer.local_option`` / ``remote_option``."""
+
+    @staticmethod
+    def enabled(key: Any) -> bool:
+        """Return ``False`` for all telnet options."""
+        return False
+
+
+class WebSocketWriter:
+    """
+    Writer that sends data over a WebSocket connection.
+
+    Presents the subset of :class:`~telnetlib3.stream_writer.TelnetWriter`
+    that the REPL and shell actually use: ``write()``, ``close()``,
+    ``is_closing()``, ``will_echo``, ``mode``, ``get_extra_info()``,
+    ``set_ext_callback()``, ``set_iac_callback()``, and ``log``.
+
+    Also provides stubs for telnet-specific attributes (``local_option``,
+    ``remote_option``, ``client``, ``_send_naws``, ``handle_send_naws``)
+    so that code shared with the telnet path does not need conditionals.
+    """
+
+    def __init__(self, ws: Any, peername: Optional[Tuple[str, int]] = None) -> None:
+        """
+        Initialise the writer.
+
+        :param ws: A ``websockets`` connection object.
+        :param peername: ``(host, port)`` tuple for ``get_extra_info("peername")``.
+        """
+        self._ws = ws
+        self._closing = False
+        self._peername = peername
+        self._ext_callback: Dict[bytes, Any] = {}
+        self._iac_callback: Dict[bytes, Any] = {}
+        self._send_queue: asyncio.Queue[Any] = asyncio.Queue()
+        self.ctx: Any = None
+        self.log = logging.getLogger("telix.ws_transport")
+        self.will_echo: bool = False
+        self.mode: str = "local"
+
+        # Telnetlib3 compatibility stubs.
+        self.local_option = _NullOptionSet()
+        self.remote_option = _NullOptionSet()
+        self.client: bool = True
+        self.handle_send_naws: Any = None
+
+    def write(self, text: Union[str, bytes]) -> None:
+        """
+        Enqueue *text* for sending as a BINARY WebSocket frame.
+
+        The actual send is performed by the :meth:`drain` background task.
+
+        :param text: Text to send (str is encoded to UTF-8; bytes passed through).
+        """
+        self._send_queue.put_nowait(text.encode("utf-8") if isinstance(text, str) else text)
+
+    def _send_naws(self) -> None:
+        """No-op stub for telnetlib3 NAWS negotiation."""
+
+    def close(self) -> None:
+        """Mark the writer as closing and signal :meth:`drain` to stop."""
+        self._closing = True
+        self._send_queue.put_nowait(None)
+
+    def is_closing(self) -> bool:
+        """Return ``True`` if :meth:`close` has been called."""
+        return self._closing
+
+    def get_extra_info(self, name: str, default: Any = None) -> Any:
+        """
+        Return transport metadata.
+
+        :param name: Key name (only ``"peername"`` and ``"ssl_object"`` supported).
+        :param default: Value to return if *name* is not available.
+        """
+        if name == "peername":
+            return self._peername if self._peername is not None else default
+        if name == "ssl_object":
+            return None
+        return default
+
+    def set_ext_callback(self, key: bytes, callback: Any) -> None:
+        r"""
+        Register an extension callback (e.g. GMCP).
+
+        :param key: Telopt byte (e.g. ``b'\xc9'`` for GMCP).
+        :param callback: Callable receiving ``(package, data)``.
+        """
+        self._ext_callback[key] = callback
+
+    def set_iac_callback(self, key: bytes, callback: Any) -> None:
+        r"""
+        Register an IAC callback (e.g. GA, EOR).
+
+        :param key: IAC command byte (e.g. ``b'\xf9'`` for GA).
+        :param callback: Callable receiving the command byte.
+        """
+        self._iac_callback[key] = callback
+
+    def dispatch_gmcp(self, package: str, data: Any) -> None:
+        """
+        Dispatch a parsed GMCP message to the registered ext callback.
+
+        :param package: GMCP package name (e.g. ``"Room.Info"``).
+        :param data: Parsed JSON payload (or ``None``).
+        """
+        cb = self._ext_callback.get(_GMCP)
+        if cb is not None:
+            cb(package, data)
+
+    def send_gmcp(self, package: str, data: Any = None) -> None:
+        """
+        Enqueue a GMCP message for sending as a TEXT WebSocket frame.
+
+        The actual send is performed by the :meth:`drain` background task.
+
+        :param package: GMCP package name.
+        :param data: JSON-serialisable payload, or ``None``.
+        """
+        if data is None:
+            self._send_queue.put_nowait(package)
+        else:
+            self._send_queue.put_nowait(f"{package} {json.dumps(data)}")
+
+    async def drain(self) -> None:
+        """
+        Send queued messages over the WebSocket until closed.
+
+        Must be run as a background task.  Items are sent in FIFO order.
+        Stops when a ``None`` sentinel is received (placed by :meth:`close`).
+        """
+        while True:
+            item = await self._send_queue.get()
+            if item is None:
+                break
+            await self._ws.send(item)
+
+    def fire_prompt_signal(self) -> None:
+        """
+        Fire GA and EOR IAC callbacks as a pseudo-prompt signal.
+
+        Called after delivering each BINARY frame's content.  WebSocket message boundaries are a
+        reliable prompt signal since each server output cycle produces one message.
+        """
+        ga_cb = self._iac_callback.get(_GA)
+        if ga_cb is not None:
+            ga_cb(_GA)
+        eor_cb = self._iac_callback.get(_CMD_EOR)
+        if eor_cb is not None:
+            eor_cb(_CMD_EOR)


### PR DESCRIPTION
## Summary

Add WebSocket protocol support to the Textual session edit screen, allowing users to configure and launch WebSocket connections through the same UI as telnet.

## Changes

### Session Edit Screen (`client_tui.py`)

- **Protocol radio** (Telnet/WebSocket) in the Connection tab
- **WS Path input** field, shown only when WebSocket is selected
- **Automatic port switching**: toggles between 23 (telnet) and 443 (WebSocket) when switching protocols
- **Server Type and MCCP Compression hidden** when WebSocket is active (MCCP is telnet-only)
- **`build_command()`** dispatches to `_build_ws_command()` for WebSocket sessions, constructing the `wss://` or `ws://` URL with optional path
- **`SessionConfig`** gains `protocol` (`"telnet"` or `"websocket"`) and `ws_path` fields, serialized to `sessions.json`

### CSS

- `#protocol-radio`, `#protocol-row`: `height: auto` to prevent clipping
- `#ws-path-row`: hidden by default, shown via `.visible` class when WebSocket selected
- `#server-type-col.ws-hidden`, `#compression-col.ws-hidden`: `display: none` when WebSocket active

### Tests (`test_client_tui.py`)

- 7+ new tests covering `build_command` / `_build_ws_command` variants (SSL, custom port, ws_path, defaults)

## Dependencies

- Requires #4 (WebSocket transport) which provides `ws_transport.py`, `ws_client.py`, and the `telix-ws` entry point

## Testing

All 865 tests pass on py313.

## Disclosure

This PR was authored with the assistance of an AI coding agent (Claude, via OpenCode). All changes were reviewed and tested by a human before submission.