### PR TITLE
GMCP fix defaults, Room.Info identifier, logfile rewrite default, TUI crash hooks

### DIFF
--- a/docs/history.rst
+++ b/docs/history.rst
@@ -1,6 +1,14 @@
 History
 =======
 
+0.1.10 -- 2026-07-15
+--------------------
+
+- bugfix: gmcp and room identifiers for Discworld MUD
+- bugfix: MUD TUI crashes due to CSS error
+- enhancement: log Textualie exceptions and css linting
+- ATASCII raw mode ESC/return fixes
+
 0.1.9 -- 2026-07-13
 -------------------
 

--- a/telix/__init__.py
+++ b/telix/__init__.py
@@ -3,4 +3,4 @@
 __author__ = "Jeff Quast"
 __url__ = "https://github.com/jquast/telix/"
 __license__ = "ISC"
-__version__ = "0.1.9"
+__version__ = "0.1.10"

--- a/telix/client_repl_dialogs.py
+++ b/telix/client_repl_dialogs.py
@@ -140,7 +140,12 @@ def run_in_thread(
     finally:
         subprocess_is_active = False
         if thread_exc is not None:
-            log.error("TUI thread failed", exc_info=thread_exc)
+            if isinstance(thread_exc, SystemExit) and thread_exc.code == 0:
+                log.debug("TUI thread exited normally (SystemExit 0)")
+            else:
+                log.error("TUI thread failed", exc_info=thread_exc)
+        else:
+            log.debug("TUI thread completed without error")
         restore_after_subprocess(replay_buf)
         for path in cleanup_files or ():
             try:

--- a/telix/client_shell.py
+++ b/telix/client_shell.py
@@ -90,6 +90,22 @@ def _apply_delete_to_backspace(stdin: typing.Any) -> None:
     stdin.read = _delete_to_backspace  # type: ignore[method-assign]
 
 
+def _apply_atascii_return(stdin: typing.Any) -> None:
+    """
+    Patch stdin so Enter (0x0d) is sent as ATASCII Return (0x9b).
+
+    ATASCII uses byte 0x9B as its end-of-line character, not ASCII CR (0x0D). Raw ATASCII connections must send 0x9B for
+    the Enter key so the server can detect ATASCII-capable clients.
+    """
+    _real_read = stdin.read
+
+    async def _cr_to_atascii_eol(n: int = -1) -> bytes:
+        data = await _real_read(n)
+        return data.replace(b"\r", b"\x9b")
+
+    stdin.read = _cr_to_atascii_eol  # type: ignore[method-assign]
+
+
 def load_configs(ctx: "session_context.TelixSessionContext") -> None:
     """
     Create config/data directories and load all per-session config files into *ctx*.
@@ -753,6 +769,8 @@ async def telix_client_shell(
             stdin = await tty_shell.connect_stdin()  # pylint: disable=no-member
             if not ctx.repl.ansi_keys:
                 _apply_delete_to_backspace(stdin)
+            if (ctx.encoding or "").startswith("atascii"):
+                _apply_atascii_return(stdin)
             state = telnetlib3.client_shell._RawLoopState(
                 switched_to_raw=switched_to_raw, last_will_echo=last_will_echo, local_echo=local_echo, linesep=linesep
             )
@@ -855,6 +873,8 @@ async def ssh_client_shell(ssh_reader: ssh_transport.SSHReader, ssh_writer: ssh_
             stdin = await tty_shell.connect_stdin()  # pylint: disable=no-member
             if not ctx.repl.ansi_keys:
                 _apply_delete_to_backspace(stdin)
+            if ssh_writer.encoding == "atascii":
+                _apply_atascii_return(stdin)
             state = telnetlib3.client_shell._RawLoopState(
                 switched_to_raw=True, last_will_echo=False, local_echo=False, linesep=linesep
             )
@@ -863,7 +883,8 @@ async def ssh_client_shell(ssh_reader: ssh_transport.SSHReader, ssh_writer: ssh_
 
             ts_path = getattr(ssh_writer, "typescript", "")
             if ts_path:
-                ts_file = open(ts_path, "wb")
+                ts_mode = getattr(ssh_writer, "typescript_mode", "append")
+                ts_file = open(ts_path, "wb" if ts_mode == "rewrite" else "ab")
                 _inner_write = raw_stdout.write
 
                 def _tee_write(data: bytes) -> None:
@@ -1000,6 +1021,8 @@ async def ws_client_shell(ws_reader: ws_transport.WebSocketReader, ws_writer: ws
             stdin = await tty_shell.connect_stdin()  # pylint: disable=no-member
             if not ctx.repl.ansi_keys:
                 _apply_delete_to_backspace(stdin)
+            if (ctx.encoding or "").startswith("atascii"):
+                _apply_atascii_return(stdin)
             state = telnetlib3.client_shell._RawLoopState(
                 switched_to_raw=True,
                 last_will_echo=False,

--- a/telix/client_tui_bars.py
+++ b/telix/client_tui_bars.py
@@ -54,14 +54,17 @@ class ProgressBarEditPane(client_tui_base.EditListPane):
     DEFAULT_CSS = (
         client_tui_base.EditListPane.DEFAULT_CSS
         + """#progressbar-form { padding: 0 0 0 4; } #progressbar-form .form-label { width: 12; } #progressbar-form
-          Input { max-width: 50; } #progressbar-form Select { max-width: 50; } #pb-gmcp-select { max-width: 18; } #pb-
-          value-select { max-width: 18; } #pb-max-select { max-width: 18; } #pb-color-swatch-max { width: 4; height: 1;
-          padding-top: 1; } #pb-color-swatch-min { width: 4; height: 1; padding-top: 1; } #pb-color-row1 { height: auto;
-          margin: 0; } #pb-color-row2 { height: auto; margin: 0; } #pb-color-row3 { height: auto; margin: 0; } #pb-
-          color-mode { max-width: 20; } #pb-color-max { width: 28; } #pb-color-min { width: 28; } #pb-text-min { width:
-          28; } #pb-text-max { width: 28; } #pb-color-path { max-width: 20; } #pb-side { max-width: 20; } #pb-preview-
-          bar { height: 1; margin: 0 0 0 12; } #pb-preview-gradient { height: 1; margin: 0 0 0 12; } #pb-bar-type { max-
-          width: 20; } #pb-label-format { max-width: 50; } #pb-label-format-row { height: auto; margin: 0; }"""
+          Input { max-width: 50; } #progressbar-form Select { max-width: 50; } #pb-gmcp-select { max-width: 18; }
+          #pb-value-select { max-width: 18; } #pb-max-select { max-width: 18; }
+          #pb-color-swatch-max { width: 4; height: 1; padding-top: 1; }
+          #pb-color-swatch-min { width: 4; height: 1; padding-top: 1; }
+          #pb-color-row1 { height: auto; margin: 0; } #pb-color-row2 { height: auto; margin: 0; }
+          #pb-color-row3 { height: auto; margin: 0; }
+          #pb-color-mode { max-width: 20; } #pb-color-max { width: 28; } #pb-color-min { width: 28; } #pb-text-min {
+          width: 28; } #pb-text-max { width: 28; } #pb-color-path { max-width: 20; } #pb-side { max-width: 20; }
+          #pb-preview-bar { height: 1; margin: 0 0 0 12; } #pb-preview-gradient { height: 1; margin: 0 0 0 12; }
+          #pb-bar-type { max-width: 20; } #pb-label-format { max-width: 50; } #pb-label-format-row { height: auto;
+          margin: 0; }"""
 
     )
 

--- a/telix/client_tui_base.py
+++ b/telix/client_tui_base.py
@@ -9,6 +9,8 @@ editor entry points.  Session management (SessionConfig, SessionListScreen, etc.
 # std imports
 import os
 import abc
+import sys
+import select
 import typing
 import logging
 from typing import TYPE_CHECKING
@@ -591,6 +593,22 @@ class EditorApp(textual.app.App[None]):
         super().__init__()
         self.editor_screen = screen
         self.session_key = session_key
+        import types
+        import traceback
+
+        real_handle = self._handle_exception
+
+        def hooked_handler(self: typing.Any, error: Exception) -> None:
+            log.error("EditorApp._handle_exception: %r", error, exc_info=error)
+            try:
+                with open("/tmp/telix-tui-crash.log", "a") as crash_fh:
+                    crash_fh.write("".join(traceback.format_exception(type(error), error, error.__traceback__)))
+                    crash_fh.write("\n")
+            except OSError:
+                pass
+            real_handle(error)
+
+        self._handle_exception = types.MethodType(hooked_handler, self)  # type: ignore[method-assign]
 
     def on_mouse_down(self, event: textual.events.MouseDown) -> None:
         """Paste X11 primary selection on middle-click."""
@@ -625,6 +643,7 @@ class EditorApp(textual.app.App[None]):
             self.theme = saved_theme
         else:
             self.theme = "gruvbox"
+
         self.push_screen(self.editor_screen, callback=lambda _: self.exit())
 
     def watch_theme(self, old: str, new: str) -> None:
@@ -708,4 +727,35 @@ def launch_editor_in_thread(screen: textual.screen.Screen[typing.Any], session_k
     """
     log_child_diagnostics()
     patch_writer_thread_queue()
+
+    # Drain and log any stale data on stdin before Textual starts.
+    # Terminal query responses (XTWINOPS, DSR, etc.) can arrive between
+    # the REPL releasing the terminal and Textual acquiring it, causing the
+    # app to exit immediately.
+    drained: list[bytes] = []
+    try:
+        fd = sys.stdin.fileno()
+        was_blocking = os.get_blocking(fd)
+        os.set_blocking(fd, False)
+        while True:
+            r, _, _ = select.select([fd], [], [], 0)
+            if not r:
+                break
+            chunk = os.read(fd, 4096)
+            if not chunk:
+                break
+            drained.append(chunk)
+    except (OSError, ValueError):
+        pass
+    finally:
+        try:
+            os.set_blocking(fd, was_blocking)
+        except OSError:
+            pass
+
+    if drained:
+        log.warning("drained %d bytes from stdin before Textual launch: %r", sum(len(c) for c in drained), drained)
+    else:
+        log.debug("stdin clean before Textual launch")
+
     EditorApp(screen, session_key=session_key).run()

--- a/telix/client_tui_session_manager.py
+++ b/telix/client_tui_session_manager.py
@@ -467,9 +467,9 @@ class SessionConfig:
     always_do: str = ""
     loglevel: str = "warn"
     logfile: str = ""
-    logfile_mode: str = "append"
+    logfile_mode: str = "rewrite"
     typescript: str = ""
-    typescript_mode: str = "append"
+    typescript_mode: str = "rewrite"
     no_repl: bool = False
 
     # Developer
@@ -791,8 +791,12 @@ def build_ssh_command(config: SessionConfig) -> list[str]:
         cmd += ["--loglevel", config.loglevel]
     if config.logfile:
         cmd += ["--logfile", config.logfile]
+        if config.logfile_mode != "append":
+            cmd += ["--logfile-mode", config.logfile_mode]
     if config.typescript:
         cmd += ["--typescript", config.typescript]
+        if config.typescript_mode != "append":
+            cmd += ["--typescript-mode", config.typescript_mode]
     append_clear_homes_flag(cmd, config)
     append_graphics_flags(cmd, config)
     return cmd
@@ -833,8 +837,12 @@ def build_raw_command(config: SessionConfig) -> list[str]:
         cmd += ["--loglevel", config.loglevel]
     if config.logfile:
         cmd += ["--logfile", config.logfile]
+        if config.logfile_mode != "append":
+            cmd += ["--logfile-mode", config.logfile_mode]
     if config.typescript:
         cmd += ["--typescript", config.typescript]
+        if config.typescript_mode != "append":
+            cmd += ["--typescript-mode", config.typescript_mode]
     append_clear_homes_flag(cmd, config)
     append_graphics_flags(cmd, config)
     return cmd
@@ -1509,8 +1517,11 @@ class SessionEditScreen(textual.screen.Screen[SessionConfig | None]):
     #loglevel-spacer {
         width: 22;
     }
-    #tab-terminal > *, #tab-display > *, #tab-advanced > * {
+    #tab-terminal > *, #tab-display > * {
         margin-bottom: 1;
+    }
+    #tab-advanced .field-label {
+        padding-top: 0;
     }
     #tab-display > #palette-row {
         margin-bottom: 0;

--- a/telix/color_filter.py
+++ b/telix/color_filter.py
@@ -569,6 +569,7 @@ _ATASCII_CONTROL_CODES: dict[str, str] = {
     "\u25c0": "\x08\x1b[P",  # ◀  backspace/delete (0x7E / 0xFE)
     "\u25b6": "\t",  # ▶  tab (0x7F / 0xFF)
     "\u21b0": "\x1b[2J\x1b[H",  # ↰  clear screen (0x7D / 0xFD)
+    "\u241b": "\x1b",  # ␛  escape (0x1B)
     "\u2191": "\x1b[A",  # ↑  cursor up (0x1C / 0x9C)
     "\u2193": "\x1b[B",  # ↓  cursor down (0x1D / 0x9D)
     "\u2190": "\x1b[D",  # ←  cursor left (0x1E / 0x9E)
@@ -583,6 +584,7 @@ ATASCII_CTRL_RE = re.compile("[" + re.escape("".join(sorted(_ATASCII_CONTROL_COD
 _ATASCII_CONTROL_BYTES: dict[int, bytes] = {
     0x08: b"\x08\x1b[P",  # BS (decodes to U+25E2 ◢)
     0x09: b"\t",  # TAB (decodes to U+2597 ▗)
+    0x1B: b"\x1b",  # ESC (decodes to U+241B ␛)
     0x1C: b"\x1b[A",  # cursor up (decodes to U+2191 ↑)
     0x1D: b"\x1b[B",  # cursor down (decodes to U+2193 ↓)
     0x1E: b"\x1b[D",  # cursor left (decodes to U+2190 ←)

--- a/telix/data/favorites.ini
+++ b/telix/data/favorites.ini
@@ -114,3 +114,11 @@ host = medievia.com
 type = mud
 port = 4000
 encoding = cp1252
+
+[Nebbs]
+host = nebbs.servehttp.com
+port = 9223
+type = bbs
+protocol = raw
+mode = raw
+encoding = atascii

--- a/telix/main.py
+++ b/telix/main.py
@@ -178,7 +178,12 @@ def build_help_parser() -> argparse.ArgumentParser:
     conn.add_argument("--gmcp-modules", metavar="MODULES", help="comma-separated list of GMCP modules to request")
     conn.add_argument("--line-mode", action="store_true", help="force line-mode input (default: auto-detect)")
     conn.add_argument("--logfile", metavar="FILE", help="write log to FILE")
-    conn.add_argument("--logfile-mode", choices=["append", "rewrite"], help="log file write mode (default: append)")
+    conn.add_argument(
+        "--logfile-mode",
+        choices=["append", "rewrite"],
+        default="rewrite",
+        help="log file write mode (default: rewrite)",
+    )
     conn.add_argument("--loglevel", help="logging level (default: warn)")
     conn.add_argument("--no-repl", action="store_true", help="disable the interactive REPL (raw I/O only)")
     conn.add_argument("--raw-mode", action="store_true", help="force raw-mode input (default: auto-detect)")

--- a/telix/mtts.py
+++ b/telix/mtts.py
@@ -125,6 +125,7 @@ class TelixClient(telnetlib3.client.TelnetClient):
             return
         self._gmcp_hello_sent = True
         hello = self.gmcp_hello or {"client": "Telix", "version": version}
+
         self.writer.send_gmcp("Core.Hello", hello)
         self.writer.send_gmcp("Core.Supports.Set", self._gmcp_modules)
         self.log.info("GMCP handshake: Core.Hello + Core.Supports.Set %s", self._gmcp_modules)

--- a/telix/raw_client.py
+++ b/telix/raw_client.py
@@ -38,6 +38,7 @@ async def run_raw_client(
     encoding: str = "utf-8",
     encoding_errors: str = "replace",
     typescript: str = "",
+    typescript_mode: str = "append",
     ansi_keys: bool = False,
     ascii_eol: bool = False,
 ) -> None:
@@ -63,6 +64,7 @@ async def run_raw_client(
     writer.encoding = encoding
     writer.encoding_errors = encoding_errors
     writer.typescript = typescript  # type: ignore[attr-defined]
+    writer.typescript_mode = typescript_mode  # type: ignore[attr-defined]
     writer.ascii_eol = ascii_eol  # type: ignore[attr-defined]
 
     shell_task = asyncio.ensure_future(shell(reader, writer))
@@ -105,7 +107,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="logging level (default: warn)",
     )
     conn.add_argument("--logfile", default="", metavar="FILE", help="write log to FILE")
+    conn.add_argument(
+        "--logfile-mode",
+        default="append",
+        choices=["append", "rewrite"],
+        help="log file write mode: append (default) or rewrite",
+    )
     conn.add_argument("--typescript", default="", metavar="FILE", help="record session to FILE")
+    conn.add_argument(
+        "--typescript-mode",
+        default="append",
+        choices=["append", "rewrite"],
+        help="typescript write mode: append (default) or rewrite",
+    )
     conn.add_argument("--encoding", default="utf-8", metavar="ENC", help="connection encoding (default: utf-8)")
     conn.add_argument(
         "--encoding-errors", default="replace", metavar="POLICY", help="encoding error handling (default: replace)"
@@ -200,6 +214,11 @@ async def raw_client_shell(raw_reader: raw_transport.RawReader, raw_writer: raw_
     ctx.raw_mode = True
     ctx.ascii_eol = getattr(raw_writer, "ascii_eol", False)
 
+    typescript = getattr(raw_writer, "typescript", "")
+    typescript_mode = getattr(raw_writer, "typescript_mode", "append")
+    if typescript:
+        ctx.typescript_file = open(typescript, "w" if typescript_mode == "rewrite" else "a", encoding="utf-8")
+
     load_configs(ctx)
     setup_color_filter(ctx, raw_writer)  # type: ignore[arg-type]
     setup_clear_homes(ctx)
@@ -241,6 +260,10 @@ async def raw_client_shell(raw_reader: raw_transport.RawReader, raw_writer: raw_
                 from .client_shell import _apply_delete_to_backspace
 
                 _apply_delete_to_backspace(stdin)
+            if raw_writer.encoding == "atascii":
+                from .client_shell import _apply_atascii_return
+
+                _apply_atascii_return(stdin)
             state = telnetlib3.client_shell._RawLoopState(
                 switched_to_raw=True, last_will_echo=False, local_echo=False, linesep=linesep
             )
@@ -290,7 +313,10 @@ def main() -> None:
     level = _LEVEL_MAP[args.loglevel]
     if args.logfile:
         logging.basicConfig(
-            level=level, filename=args.logfile, filemode="w", format="%(levelname)s %(filename)s:%(lineno)d %(message)s"
+            level=level,
+            filename=args.logfile,
+            filemode="w" if args.logfile_mode == "rewrite" else "a",
+            format="%(levelname)s %(filename)s:%(lineno)d %(message)s",
         )
     else:
         logging.basicConfig(level=level, format="%(levelname)s %(filename)s:%(lineno)d %(message)s")
@@ -304,6 +330,7 @@ def main() -> None:
             encoding=args.encoding,
             encoding_errors=args.encoding_errors,
             typescript=args.typescript,
+            typescript_mode=args.typescript_mode,
             ansi_keys=args.ansi_keys,
             ascii_eol=args.ascii_eol,
         )

--- a/telix/rooms.py
+++ b/telix/rooms.py
@@ -27,7 +27,7 @@ EXIT_DIR_RE = re.compile(
 )
 
 
-ROOM_ID_KEYS = ("num", "vnum", "id")
+ROOM_ID_KEYS = ("num", "vnum", "id", "identifier")
 
 
 def room_id(info: dict[str, typing.Any]) -> str | None:

--- a/telix/ssh_client.py
+++ b/telix/ssh_client.py
@@ -139,6 +139,7 @@ async def run_ssh_client(
     encoding: str = "utf-8",
     encoding_errors: str = "replace",
     typescript: str = "",
+    typescript_mode: str = "append",
 ) -> None:
     """
     Connect to an SSH server and run the telix shell.
@@ -163,6 +164,7 @@ async def run_ssh_client(
     writer.encoding = encoding
     writer.encoding_errors = encoding_errors
     writer.typescript = typescript  # type: ignore[attr-defined]
+    writer.typescript_mode = typescript_mode  # type: ignore[attr-defined]
 
     shell_task = asyncio.ensure_future(shell(reader, writer))
 
@@ -214,7 +216,19 @@ def build_parser() -> argparse.ArgumentParser:
         help="logging level (default: warn)",
     )
     conn.add_argument("--logfile", default="", metavar="FILE", help="write log to FILE")
+    conn.add_argument(
+        "--logfile-mode",
+        default="append",
+        choices=["append", "rewrite"],
+        help="log file write mode: append (default) or rewrite",
+    )
     conn.add_argument("--typescript", default="", metavar="FILE", help="record session to FILE")
+    conn.add_argument(
+        "--typescript-mode",
+        default="append",
+        choices=["append", "rewrite"],
+        help="typescript write mode: append (default) or rewrite",
+    )
     conn.add_argument("--encoding", default="utf-8", metavar="ENC", help="connection encoding (default: utf-8)")
     conn.add_argument(
         "--encoding-errors", default="replace", metavar="POLICY", help="encoding error handling (default: replace)"
@@ -300,7 +314,10 @@ def main() -> None:
     level = _LEVEL_MAP[args.loglevel]
     if args.logfile:
         logging.basicConfig(
-            level=level, filename=args.logfile, filemode="w", format="%(levelname)s %(filename)s:%(lineno)d %(message)s"
+            level=level,
+            filename=args.logfile,
+            filemode="w" if args.logfile_mode == "rewrite" else "a",
+            format="%(levelname)s %(filename)s:%(lineno)d %(message)s",
         )
     else:
         logging.basicConfig(level=level, format="%(levelname)s %(filename)s:%(lineno)d %(message)s")
@@ -317,6 +334,7 @@ def main() -> None:
             encoding=args.encoding,
             encoding_errors=args.encoding_errors,
             typescript=args.typescript,
+            typescript_mode=args.typescript_mode,
         )
     )
     sys.exit(0)

--- a/telix/tests/test_client_shell.py
+++ b/telix/tests/test_client_shell.py
@@ -810,3 +810,30 @@ class TestComputeLocalEcho:
     def test_remote_mode(self) -> None:
         assert compute_local_echo("remote", True) is False
         assert compute_local_echo("remote", False) is False
+
+
+def test_apply_atascii_return_translates_cr() -> None:
+    from telix.client_shell import _apply_atascii_return
+
+    class Stdin:
+        def __init__(self) -> None:
+            self.data = b"hello\rworld\r"
+
+        async def read(self, n: int = -1) -> bytes:
+            return self.data
+
+    stdin = Stdin()
+    orig_read = stdin.read
+    _apply_atascii_return(stdin)
+    assert stdin.read is not orig_read
+
+
+def test_apply_atascii_return_passthrough_non_cr() -> None:
+    from telix.client_shell import _apply_atascii_return
+
+    class Stdin:
+        async def read(self, n: int = -1) -> bytes:
+            return b"hello world"
+
+    stdin = Stdin()
+    _apply_atascii_return(stdin)

--- a/telix/tests/test_color_filter.py
+++ b/telix/tests/test_color_filter.py
@@ -643,6 +643,7 @@ def test_petscii_default_config() -> None:
         ("\u25c0", "\x08\x1b[P"),
         ("\u25b6", "\t"),
         ("\u21b0", "\x1b[2J\x1b[H"),
+        ("\u241b", "\x1b"),
         ("\u2191", "\x1b[A"),
         ("\u2193", "\x1b[B"),
         ("\u2190", "\x1b[D"),
@@ -697,6 +698,12 @@ def test_atascii_filter_bytes_clear_screen() -> None:
     f = AtasciiControlFilter()
     assert f.filter_bytes(b"\x7d") == b"\x1b[2J\x1b[H"
     assert f.filter_bytes(b"\xfd") == b"\x1b[2J\x1b[H"
+
+
+def test_atascii_filter_bytes_escape() -> None:
+    f = AtasciiControlFilter()
+    assert f.filter_bytes(b"\x1b") == b"\x1b"
+    assert f.filter_bytes(b"\x1b[2J") == b"\x1b[2J"
 
 
 def test_atascii_filter_bytes_tab() -> None:

--- a/telix/tests/test_css_validate.py
+++ b/telix/tests/test_css_validate.py
@@ -1,0 +1,53 @@
+"""Validate all DEFAULT_CSS strings parses without syntax errors."""
+
+import ast
+
+import pytest
+from textual.css.errors import UnresolvedVariableError
+from textual.css.stylesheet import Stylesheet
+
+
+def find_css_strings(source: str, filename: str) -> list[tuple[int, str]]:
+    results: list[tuple[int, str]] = []
+    try:
+        tree = ast.parse(source, filename=filename)
+    except SyntaxError:
+        return results
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "DEFAULT_CSS":
+                    if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                        results.append((node.lineno, node.value.value))
+                    elif isinstance(node.value, ast.BinOp):
+                        parts: list[str] = []
+                        for sub in ast.walk(node.value):
+                            if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                                parts.append(sub.value)
+                        if parts:
+                            results.append((node.lineno, "".join(parts)))
+    return results
+
+
+def collect_css_targets():
+    import telix
+
+    root = telix.__path__[0]
+    from pathlib import Path
+
+    targets: list[tuple[str, int, str]] = []
+    for pyfile in sorted(Path(root).rglob("*.py")):
+        source = pyfile.read_text(encoding="utf-8")
+        for lineno, css in find_css_strings(source, str(pyfile)):
+            targets.append((pyfile.name, lineno, css))
+    return targets
+
+
+@pytest.mark.parametrize("filename,lineno,css", collect_css_targets())
+def test_default_css_parses(filename, lineno, css):
+    stylesheet = Stylesheet()
+    stylesheet.add_source(css)
+    try:
+        stylesheet.parse()
+    except UnresolvedVariableError:
+        pass

--- a/tools/validate_css.py
+++ b/tools/validate_css.py
@@ -1,0 +1,55 @@
+"""Validate Textual DEFAULT_CSS strings in all Python source files."""
+
+import ast
+import sys
+from pathlib import Path
+
+from textual.css.stylesheet import Stylesheet
+from textual.css.errors import UnresolvedVariableError
+
+
+def find_css_strings(source: str, filename: str) -> list[tuple[int, str]]:
+    """Extract DEFAULT_CSS string values from a Python source."""
+    results: list[tuple[int, str]] = []
+    try:
+        tree = ast.parse(source, filename=filename)
+    except SyntaxError:
+        return results
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Assign):
+            for target in node.targets:
+                if isinstance(target, ast.Name) and target.id == "DEFAULT_CSS":
+                    if isinstance(node.value, ast.Constant) and isinstance(node.value.value, str):
+                        results.append((node.lineno, node.value.value))
+                    elif isinstance(node.value, ast.BinOp):
+                        parts: list[str] = []
+                        for sub in ast.walk(node.value):
+                            if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+                                parts.append(sub.value)
+                        if parts:
+                            results.append((node.lineno, "".join(parts)))
+    return results
+
+
+def main() -> int:
+    """Validate all DEFAULT_CSS strings under telix/."""
+    root = Path(__file__).resolve().parent.parent / "telix"
+    errors = 0
+    for pyfile in sorted(root.rglob("*.py")):
+        source = pyfile.read_text(encoding="utf-8")
+        for lineno, css in find_css_strings(source, str(pyfile)):
+            stylesheet = Stylesheet()
+            stylesheet.add_source(css)
+            try:
+                stylesheet.parse()
+            except UnresolvedVariableError:
+                pass
+            except Exception as exc:
+                print(f"{pyfile}:{lineno}: CSS parse error: {exc}", file=sys.stderr)
+                errors += 1
+    return 1 if errors else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tox.ini
+++ b/tox.ini
@@ -111,6 +111,7 @@ commands =
     {[testenv:ruff_check]commands}
     {[testenv:pydocstyle]commands}
     {[testenv:codespell]commands}
+    python {toxinidir}/tools/validate_css.py
 
 [testenv:build_fonts]
 basepython = python3.14


### PR DESCRIPTION
- bugfix a CSS error that caused a crash without exception logged
- bugfix the TUI crash hooks so catch those logs
- bugfix for Discworld MUD: lowercase GMCP, support Room.Info
- change default logfile mode is to 'rewrite' by default, not append
